### PR TITLE
Adding ackermann model derived from EntityBase, updating simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ MESSAGE(STATUS "Using compiler: ${CMAKE_CXX_COMPILER}")
 MESSAGE(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 MESSAGE(STATUS "Arch: ${CMAKE_SYSTEM_PROCESSOR}")
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -march=native -Werror -Wall -g -rdynamic")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -march=native -Qunused-arguments -Werror -Wall -g -rdynamic")
 
 IF(${CMAKE_BUILD_TYPE} MATCHES "Release")
   MESSAGE(STATUS "Additional Flags for Release mode")
@@ -51,6 +51,8 @@ ROSBUILD_ADD_EXECUTABLE(${target}
   src/simulator/simulator.cpp
   src/simulator/vector_map.cpp
   src/simulator/entity_base.cpp
+  src/simulator/robot_model.cpp
+  src/simulator/ackermann_model.cpp
   src/simulator/short_term_object.cpp
   src/simulator/human_object.cpp
   )

--- a/config/f1_config.lua
+++ b/config/f1_config.lua
@@ -39,3 +39,5 @@ laser_noise_stddev = 0.01
 -- Turning error simulation.
 angular_error_bias = DegToRad(0);
 angular_error_rate = 0.1;
+
+drive_callback_topic = "ackermann_curvature_drive"

--- a/manifest.xml
+++ b/manifest.xml
@@ -10,5 +10,4 @@
   <depend package="nav_msgs"/>
   <depend package="sensor_msgs"/>
   <depend package="tf"/>
-  <!-- <depend package="f1tenth_course"/> -->
 </package>

--- a/src/simulator/ackermann_model.cpp
+++ b/src/simulator/ackermann_model.cpp
@@ -1,0 +1,99 @@
+#include "simulator/ackermann_model.h"
+#include "shared/util/timer.h"
+#include "shared/math/math_util.h"
+#include <eigen3/Eigen/src/Geometry/Rotation2D.h>
+
+using Eigen::Vector2f;
+using Eigen::Rotation2Df;
+using f1tenth_simulator::AckermannCurvatureDriveMsg;
+using math_util::AbsBound;
+using math_util::AngleDiff;
+using math_util::AngleMod;
+using std::string;
+using std::isfinite;
+
+namespace robot_model {
+
+CONFIG_FLOAT(cMinTurnR, "min_turn_radius");
+CONFIG_FLOAT(cMaxAccel, "max_accel");
+CONFIG_FLOAT(cMaxSpeed, "max_speed");
+CONFIG_FLOAT(cAngularErrorBias, "angular_error_bias");
+CONFIG_FLOAT(cAngularErrorRate, "angular_error_rate");
+CONFIG_STRING(cDriveTopic, "drive_callback_topic");
+
+
+AckermannModel::AckermannModel(const string& config_file, ros::NodeHandle* n) :
+    RobotModel(),
+    last_cmd_(),
+    t_last_cmd_(0),
+    angular_error_(0, 1),
+    config_reader_({config_file}){
+  // Use the config reader to initialize the subscriber
+  last_cmd_.velocity = 0;
+  last_cmd_.curvature = 0;
+  drive_subscriber_ = n->subscribe(
+      cDriveTopic,
+      1,
+      &AckermannModel::DriveCallback,
+      this);
+}
+
+void AckermannModel::DriveCallback(const AckermannCurvatureDriveMsg& msg) {
+  if (!isfinite(msg.velocity) || !isfinite(msg.curvature)) {
+    printf("Ignoring non-finite drive values: %f %f\n",
+        msg.velocity,
+        msg.curvature);
+    return;
+  }
+  last_cmd_ = msg;
+  t_last_cmd_ = GetMonotonicTime();
+}
+
+void AckermannModel::Step(const double &dt) {
+  // TODO(jaholtz) For faster than real time simulation we may need
+  // a wallclock invariant method for this.
+  static const double kMaxCommandAge = 0.1;
+  if (GetMonotonicTime() > t_last_cmd_ + kMaxCommandAge) {
+    last_cmd_.velocity = 0;
+  }
+  const float vel = vel_.translation.x();
+  // Epsilon curvature corresponding to a very large radius of turning.
+  static const float kEpsilonCurvature = 1.0 / 1E3;
+  // Commanded speed bounded to motion limit.
+  float desired_vel = last_cmd_.velocity;
+  AbsBound(cMaxSpeed, &desired_vel);
+  // Maximum magnitude of curvature according to turning limits.
+  const float max_curvature = 1.0 / cMinTurnR;
+  // Commanded curvature bounded to turning limit.
+  float desired_curvature = last_cmd_.curvature;
+  AbsBound(max_curvature, &desired_curvature);
+  // Indicates if the command is for linear motion.
+  const bool linear_motion = (fabs(desired_curvature) < kEpsilonCurvature);
+
+  const float dv_max = dt * cMaxAccel;
+  float bounded_dv = desired_vel - vel;
+  AbsBound(dv_max, &bounded_dv);
+
+  // Set velocity
+  vel_.translation.x() = vel + bounded_dv;
+  const float dist = vel_.translation.x() * dt;
+
+  Vector2f d_vector(0,0);
+  float dtheta = 0;
+  if (linear_motion) {
+    d_vector.x() = dist;
+    dtheta = dt * cAngularErrorBias;
+  } else {
+    const float r = 1.0 / desired_curvature;
+    dtheta = dist * desired_curvature +
+        angular_error_(rng_) * dt * cAngularErrorBias +
+        angular_error_(rng_) * cAngularErrorRate * fabs(dist *
+            desired_curvature);
+    d_vector = {r * sin(dtheta), r * (1.0 - cos(dtheta))};
+  }
+  // Update the Pose
+  pose_.translation += Eigen::Rotation2Df(pose_.angle) * d_vector;
+  pose_.angle = AngleMod(pose_.angle + dtheta);
+}
+
+} // namespace robot_model

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -1,0 +1,36 @@
+#include "config_reader/config_reader.h"
+#include "f1tenth_simulator/AckermannCurvatureDriveMsg.h"
+#include "ros/ros.h"
+#include "simulator/robot_model.h"
+#include <random>
+#include <string>
+
+#ifndef SRC_SIMULATOR_ACKERMANN_MODEL_H_
+#define SRC_SIMULATOR_ACKERMANN_MODEL_H_
+
+namespace robot_model {
+
+class AckermannModel : public RobotModel {
+private:
+  f1tenth_simulator::AckermannCurvatureDriveMsg last_cmd_;
+  double t_last_cmd_;
+  std::default_random_engine rng_;
+  std::normal_distribution<float> angular_error_;
+  ros::Subscriber drive_subscriber_;
+  config_reader::ConfigReader config_reader_;
+
+  // Receives drive callback messages and stores them
+  void DriveCallback(const f1tenth_simulator::AckermannCurvatureDriveMsg &msg);
+
+public:
+  AckermannModel() = delete;
+  // Intialize a default object reading from a file
+  AckermannModel(const std::string &config_file, ros::NodeHandle *n);
+  ~AckermannModel() = default;
+  // define Step function for updating
+  void Step(const double &dt);
+};
+
+} // namespace robot_model
+
+#endif // SRC_SIMULATOR_ACKERMANN_MODEL_H_

--- a/src/simulator/entity_base.h
+++ b/src/simulator/entity_base.h
@@ -40,7 +40,7 @@ class EntityBase{
     std::vector<geometry::line2f> pose_lines_;
  public:
     EntityBase();
-    ~EntityBase();
+    virtual ~EntityBase() = default;
     // simulate a step for the object
     virtual void Step(const double& dt);
     // set current pose

--- a/src/simulator/robot_model.cpp
+++ b/src/simulator/robot_model.cpp
@@ -13,33 +13,27 @@
 //  If not, see <http://www.gnu.org/licenses/>.
 //========================================================================
 /*!
-  \file    entity_base.cpp
-  \brief   C++ Interface: Abstract class for objects
-  \author  Yifeng Zhu, (C) 2020
-  \email   yifeng.zhu@utexas.edu
+  \file    robot_model.cpp
+  \brief   C++ Interface: Abstract class for robot models
+  \author  Jarrett Holtz, (C) 2020
+  \email   jaholtz@cs.utexas.edu
 */
 //========================================================================
 
-#include "simulator/entity_base.h"
+#include "simulator/robot_model.h"
 
-EntityBase::EntityBase() {
+namespace robot_model {
+
+RobotModel::RobotModel() :
+    EntityBase(),
+    vel_(0,{0,0}) {}
+
+void RobotModel::SetVel(const pose_2d::Pose2Df& vel) {
+ vel_ = vel;
 }
 
-void EntityBase::Step(const double& dt) {
+Pose2Df RobotModel::GetVel() {
+  return vel_;
 }
 
-void EntityBase::SetPose(const Pose2Df& pose) {
-  pose_ = pose;
-}
-
-Pose2Df EntityBase::GetPose() {
-  return pose_;
-}
-
-std::vector<geometry::line2f> EntityBase::GetTemplateLines() {
-  return template_lines_;
-}
-
-std::vector<geometry::line2f> EntityBase::GetLines() {
-  return pose_lines_;
 }

--- a/src/simulator/robot_model.h
+++ b/src/simulator/robot_model.h
@@ -1,6 +1,6 @@
 //========================================================================
-//  This software is free: you can redistribute it and/or modify
-//  it under the terms of the GNU Lesser General Public License Version 3,
+//      This software is free: you can redistribute it and/or modif    y
+//  it under the terms of the GNU Lesser General Public License Vers    ion 3,
 //  as published by the Free Software Foundation.
 //
 //  This software is distributed in the hope that it will be useful,
@@ -13,33 +13,28 @@
 //  If not, see <http://www.gnu.org/licenses/>.
 //========================================================================
 /*!
-  \file    entity_base.cpp
-  \brief   C++ Interface: Abstract class for objects
-  \author  Yifeng Zhu, (C) 2020
-  \email   yifeng.zhu@utexas.edu
+  \file    robot_model.h
+  \brief   C++ Interface: Abstract class for robots built on entity_base
+  \author  Jarrett Holtz, (C) 2020
+  \email   jaholtz@cs.utexas.edu
 */
 //========================================================================
 
 #include "simulator/entity_base.h"
 
-EntityBase::EntityBase() {
-}
+#ifndef SRC_SIMULATOR_ROBOT_MODEL_H_
+#define SRC_SIMULATOR_ROBOT_MODEL_H_
 
-void EntityBase::Step(const double& dt) {
-}
+namespace robot_model {
+class RobotModel : public EntityBase {
+ protected:
+    Pose2Df vel_;
+ public:
+    RobotModel();
+    virtual ~RobotModel() = default;
+    virtual void SetVel(const pose_2d::Pose2Df& vel);
+    virtual pose_2d::Pose2Df GetVel();
+};
+}  // namespace robot_model
 
-void EntityBase::SetPose(const Pose2Df& pose) {
-  pose_ = pose;
-}
-
-Pose2Df EntityBase::GetPose() {
-  return pose_;
-}
-
-std::vector<geometry::line2f> EntityBase::GetTemplateLines() {
-  return template_lines_;
-}
-
-std::vector<geometry::line2f> EntityBase::GetLines() {
-  return pose_lines_;
-}
+#endif  // SRC_SIMULATOR_ROBOT_MODEL_H_


### PR DESCRIPTION
I was originally going to create a new abstract class to handle the motion models, but EntityBase provides everything motion models need and further allow obstacles and robots to be handled very similarly. This design choice limits duplicating parts of our interface across different abstract classes.

The alternative might be to use nested class implementations. I don't think that's necessary though, unless someone sees a reason to make motion models more distinct from other EntityBase classes.