### PR TITLE
Merging multi-bot-rebase to master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ ROSBUILD_GENMSG()
 ADD_SUBDIRECTORY(${PROJECT_SOURCE_DIR}/submodules/shared)
 INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/submodules/shared)
 
-SET(libs roslib roscpp glog gflags amrl-shared-lib
+SET(libs roslib roscpp glog gflags amrl_shared_lib
     ${BUILD_SPECIFIC_LIBRARIES} rosbag X11 lua5.1 boost_system)
 
 SET(target simulator)

--- a/config/bwibot_config.lua
+++ b/config/bwibot_config.lua
@@ -1,3 +1,6 @@
+function Vector3(x, y, z)
+  return {x = x, y = y, z = z}
+end
 -- MODEL PARAMETERS
 invert_linear_vel_cmds = false
 invert_angular_vel_cmds = false

--- a/config/cobot_config.lua
+++ b/config/cobot_config.lua
@@ -16,3 +16,8 @@ co_max_angle_accel = math.pi
 co_min_turn_radius = 0.98
 co_max_speed = 1.2
 co_max_accel = 3.0
+
+-- cobot configuration
+cobot_num_segments = 20
+cobot_radius = 0.5
+cobot_offset = {0, 0} -- position of lidar

--- a/config/default_init_config.lua
+++ b/config/default_init_config.lua
@@ -1,4 +1,4 @@
-map_name =  "maps/UT_AUTOmata_Track/UT_AUTOmata_Track.vectormap.txt"
+map_name =  "maps/AHG2_Track/AHG2_Track.vectormap.txt"
 -- Simulator starting location. 
 -- (Tongrui: moved corresponding code to topic_config.lua)
 -- start_x = 33.016267

--- a/config/default_init_config.lua
+++ b/config/default_init_config.lua
@@ -1,6 +1,6 @@
 map_name =  "maps/GDC3/GDC3.vectormap.txt"
--- Simulator starting location.
-start_x = 33.016267
-start_y = 21.534157
-start_angle = 0.0
-
+-- Simulator starting location. 
+-- (Tongrui: moved corresponding code to topic_config.lua)
+-- start_x = 33.016267
+-- start_y = 21.534157
+-- start_angle = 0.0

--- a/config/default_init_config.lua
+++ b/config/default_init_config.lua
@@ -1,4 +1,4 @@
-map_name =  "maps/GDC3/GDC3.vectormap.txt"
+map_name =  "maps/UT_AUTOmata_Track/UT_AUTOmata_Track.vectormap.txt"
 -- Simulator starting location. 
 -- (Tongrui: moved corresponding code to topic_config.lua)
 -- start_x = 33.016267

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -49,7 +49,7 @@ laser_frame = "base_laser"
 -- define multi robot senerio
 -- The simulator will only use the first robot_number items in each list
 -- to configure each robot.
-robot_number = 1
+robot_number = 2
 
 -- topic prefix of robots
 topic_prefix_list = {"robot_0", "robot_1", "robot_2", "robot_3", "robot_4", "robot_5", "robot_6", "robot_7"}
@@ -78,7 +78,7 @@ type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACK
 config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{5.0, 1.0}, {4.0, 0}, {3.0, 0}}
+location_list = {{0.0, 0.0}, {0.0, 0.0}, {3.0, 0}}
 
 -- init angle of robots
 angle_list = {0.0, 0.0, 0.0}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -15,7 +15,7 @@ init_config_file = "config/default_init_config.lua"
 -- init_config_file = "config/human_crowd_scenario_configs/example_scenario/init_config.lua"
 
 -- Time-step for simulation.
-delta_t = 0.05
+delta_t = 0.005
 
 -- Simulator TF publications
 publish_tfs = true;
@@ -78,7 +78,7 @@ type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACK
 config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {0.0, 0.0}, {3.0, 0}}
+location_list = {{0.0, 0.0}, {0.8, 0.0}, {0.8, 0}}
 
 -- init angle of robots
 angle_list = {0.0, 0.0, 0.0}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -57,7 +57,7 @@ laser_frame = "base_laser"
 -- define multi robot senerio
 -- The simulator will only use the first robot_number items in each list
 -- to configure each robot.
-robot_number = 1
+robot_number = 2
 
 -- topic prefix of robots
 topic_prefix_list = {"car0", "car1", "car2"}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -15,7 +15,7 @@ init_config_file = "config/default_init_config.lua"
 -- init_config_file = "config/human_crowd_scenario_configs/example_scenario/init_config.lua"
 
 -- Time-step for simulation.
-delta_t = 0.025
+delta_t = 0.05
 
 -- Simulator TF publications
 publish_tfs = true;
@@ -33,8 +33,8 @@ laser_loc = Vector3(0.2, 0, 0.15)
 
 -- Kinematic and dynamic constraints for the car.
 min_turn_radius = 0.98
-max_speed = 1.2
-max_accel = 3.0
+max_speed = 5.0
+max_accel = 5.0
 
 -- Laser noise simulation.
 laser_noise_stddev = 0.01
@@ -49,10 +49,10 @@ laser_frame = "base_laser"
 -- define multi robot senerio
 -- The simulator will only use the first robot_number items in each list
 -- to configure each robot.
-robot_number = 2
+robot_number = 1
 
 -- topic prefix of robots
-topic_prefix_list = {"single_robot", "robot_1", "robot_2", "robot_3"}
+topic_prefix_list = {"robot_0", "robot_1", "robot_2", "robot_3", "robot_4", "robot_5", "robot_6", "robot_7"}
 
 -- Defining robot type enumerator
 local RobotType = {
@@ -72,13 +72,13 @@ local RobotType = {
 -- robot_config = "config/ut_jackal_config.lua
 
 -- type of robot
-type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.DIFF_DRIVE, RobotType.OMNIDIRECTIONAL_DRIVE, RobotType.DIFF_DRIVE}
+type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.DIFF_DRIVE, RobotType.OMNIDIRECTIONAL_DRIVE, RobotType.DIFF_DRIVE}
 
 -- config of robot
-config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
+config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {1.5, 0}, {10.0, 10.0}}
+location_list = {{5.0, 1.0}, {4.0, 0}, {3.0, 0}}
 
 -- init angle of robots
 angle_list = {0.0, 0.0, 0.0}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -49,7 +49,7 @@ laser_frame = "base_laser"
 -- define multi robot senerio
 -- The simulator will only use the first robot_number items in each list
 -- to configure each robot.
-robot_number = 2
+robot_number = 4
 
 -- topic prefix of robots
 topic_prefix_list = {"robot_0", "robot_1", "robot_2", "robot_3", "robot_4", "robot_5", "robot_6", "robot_7"}
@@ -72,17 +72,17 @@ local RobotType = {
 -- robot_config = "config/ut_jackal_config.lua
 
 -- type of robot
-type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.DIFF_DRIVE, RobotType.OMNIDIRECTIONAL_DRIVE, RobotType.DIFF_DRIVE}
+type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.DIFF_DRIVE, RobotType.OMNIDIRECTIONAL_DRIVE, RobotType.DIFF_DRIVE}
 
 -- config of robot
-config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
+config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {0.8, 0.0}, {0.8, 0}}
+location_list = {{0.0, 0.0}, {-0.5, 0.866}, {-0.5, -0.866}, {1.0, 0.0}}
 
 -- init angle of robots
-angle_list = {0.0, 0.0, 0.0}
+angle_list = {0.0, 0.0, 0.0, 0.0}
 
 -- color of robots
-RGB_list = {{255.0, 165.0, 39.0}, {52.0, 101.0, 164.0}, {92.0, 53.0, 102.0}}
+RGB_list = {{255.0, 165.0, 39.0}, {52.0, 101.0, 164.0}, {92.0, 53.0, 102.0},{255.0, 0.0, 39.0}}
 

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -78,7 +78,7 @@ type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.DIF
 config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {10.0, 0}, {10.0, 10.0}}
+location_list = {{0.0, 0.0}, {1.5, 0}, {10.0, 10.0}}
 
 -- init angle of robots
 angle_list = {0.0, 0.0, 0.0}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -49,7 +49,7 @@ laser_frame = "base_laser"
 -- define multi robot senerio
 -- The simulator will only use the first robot_number items in each list
 -- to configure each robot.
-robot_number = 2
+robot_number = 3
 
 -- topic prefix of robots
 topic_prefix_list = {"robot_0", "robot_1", "robot_2", "robot_3", "robot_4", "robot_5", "robot_6", "robot_7"}
@@ -78,11 +78,11 @@ type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACK
 config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {0.0, 0.5}, {-0.5, -0.866}, {1.0, 0.0}}
+location_list = {{3.0, 74.2}, {3.5, 75}, {2.5, 75}, {1.0, 0.0}}
 -- 4 car setting location_list = {{0.0, 0.0}, {-0.5, 0.866}, {-0.5, -0.866}, {1.0, 0.0}}
 
 -- init angle of robots
-angle_list = {0.0, 0.0, 0.0, 0.0}
+angle_list = {-1.8, -1.5, -1.7, 0.0}
 
 -- color of robots
 RGB_list = {{255.0, 165.0, 39.0}, {52.0, 101.0, 164.0}, {92.0, 53.0, 102.0},{255.0, 0.0, 39.0}}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -43,6 +43,25 @@ laser_noise_stddev = 0.01
 angular_error_bias = DegToRad(0);
 angular_error_rate = 0.1;
 
+-- (Tongrui: handled multi robot case)
+-- robot_type = RobotType.F1TEN
+-- robot_config = "config/ackermann_config.lua"
+-- robot_type = RobotType.BWIBOT
+-- robot_config = "config/bwibot_config.lua"
+-- robot_type = RobotType.COBOT 
+-- robot_config = "config/cobot_config.lua"
+
+laser_topic = "/Cobot/Laser"
+laser_frame = "base_laser"
+
+-- define multi robot senerio
+-- The simulator will only use the first robot_number items in each list
+-- to configure each robot.
+robot_number = 1
+
+-- topic prefix of robots
+topic_prefix_list = {"car0", "car1", "car2"}
+
 -- Defining robot type enumerator
 local RobotType = {
     ACKERMANN_DRIVE="ACKERMANN_DRIVE",
@@ -50,14 +69,26 @@ local RobotType = {
     DIFF_DRIVE="DIFF_DRIVE"
 }
 
-robot_type = RobotType.ACKERMANN_DRIVE
-robot_config = "config/ut_automata_config.lua"
--- robot_type = RobotType.DIFF_DRIVE
+--(Tongrui Li: rplease use type_list and config_list below)
+-- robot_type = RobotType.F1TEN
+-- robot_config = "config/ackermann_config.lua"
+-- robot_type = RobotType.BWIBOT
 -- robot_config = "config/bwibot_config.lua"
--- robot_type = RobotType.OMNIDIRECTIONAL_DRIVE
+-- robot_type = RobotType.COBOT
 -- robot_config = "config/cobot_config.lua"
--- robot_type = RobotType.DIFF_DRIVE
--- robot_config = "config/ut_jackal_config.lua"
 
-laser_topic = "/Cobot/Laser"
-laser_frame = "base_laser"
+-- type of robot
+type_list = {"F1TEN", "COBOT", "BWIBOT"}
+
+-- config of robot
+config_list = {"config/ackermann_config.lua", "config/cobot_config.lua", "config/cobot_config.lua"}
+
+-- init cartesian location of robots
+location_list = {{0.0, 0.0}, {-10.0, 10.0}, {10.0, 10.0}}
+
+-- init angle of robots
+angle_list = {0.0, 0.0, 0.0}
+
+-- color of robots
+RGB_list = {{255.0, 165.0, 39.0}, {52.0, 101.0, 164.0}, {92.0, 53.0, 102.0}}
+

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -43,14 +43,6 @@ laser_noise_stddev = 0.01
 angular_error_bias = DegToRad(0);
 angular_error_rate = 0.1;
 
--- (Tongrui: handled multi robot case)
--- robot_type = RobotType.F1TEN
--- robot_config = "config/ackermann_config.lua"
--- robot_type = RobotType.BWIBOT
--- robot_config = "config/bwibot_config.lua"
--- robot_type = RobotType.COBOT 
--- robot_config = "config/cobot_config.lua"
-
 laser_topic = "/Cobot/Laser"
 laser_frame = "base_laser"
 
@@ -60,7 +52,7 @@ laser_frame = "base_laser"
 robot_number = 2
 
 -- topic prefix of robots
-topic_prefix_list = {"car0", "car1", "car2"}
+topic_prefix_list = {"single_robot", "robot_1", "robot_2", "robot_3"}
 
 -- Defining robot type enumerator
 local RobotType = {
@@ -70,21 +62,23 @@ local RobotType = {
 }
 
 --(Tongrui Li: rplease use type_list and config_list below)
--- robot_type = RobotType.F1TEN
--- robot_config = "config/ackermann_config.lua"
--- robot_type = RobotType.BWIBOT
+-- robot_type = RobotType.ACKERMANN_DRIVE
+-- robot_config = "config/ut_automata_config.lua"
+-- robot_type = RobotType.DIFF_DRIVE
 -- robot_config = "config/bwibot_config.lua"
--- robot_type = RobotType.COBOT
+-- robot_type = RobotType.OMNIDIRECTIONAL_DRIVE
 -- robot_config = "config/cobot_config.lua"
+-- robot_type = RobotType.DIFF_DRIVE
+-- robot_config = "config/ut_jackal_config.lua
 
 -- type of robot
-type_list = {"F1TEN", "COBOT", "BWIBOT"}
+type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.DIFF_DRIVE, RobotType.OMNIDIRECTIONAL_DRIVE, RobotType.DIFF_DRIVE}
 
 -- config of robot
-config_list = {"config/ackermann_config.lua", "config/cobot_config.lua", "config/cobot_config.lua"}
+config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {-10.0, 10.0}, {10.0, 10.0}}
+location_list = {{0.0, 0.0}, {10.0, 0}, {10.0, 10.0}}
 
 -- init angle of robots
 angle_list = {0.0, 0.0, 0.0}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -15,7 +15,7 @@ init_config_file = "config/default_init_config.lua"
 -- init_config_file = "config/human_crowd_scenario_configs/example_scenario/init_config.lua"
 
 -- Time-step for simulation.
-delta_t = 0.005
+delta_t = 0.02
 
 -- Simulator TF publications
 publish_tfs = true;
@@ -49,7 +49,7 @@ laser_frame = "base_laser"
 -- define multi robot senerio
 -- The simulator will only use the first robot_number items in each list
 -- to configure each robot.
-robot_number = 4
+robot_number = 2
 
 -- topic prefix of robots
 topic_prefix_list = {"robot_0", "robot_1", "robot_2", "robot_3", "robot_4", "robot_5", "robot_6", "robot_7"}
@@ -78,7 +78,8 @@ type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACK
 config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {-0.5, 0.866}, {-0.5, -0.866}, {1.0, 0.0}}
+location_list = {{0.0, 0.0}, {1.0, 0}, {-0.5, -0.866}, {1.0, 0.0}}
+-- 4 car setting location_list = {{0.0, 0.0}, {-0.5, 0.866}, {-0.5, -0.866}, {1.0, 0.0}}
 
 -- init angle of robots
 angle_list = {0.0, 0.0, 0.0, 0.0}

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -78,7 +78,7 @@ type_list = {RobotType.ACKERMANN_DRIVE, RobotType.ACKERMANN_DRIVE, RobotType.ACK
 config_list = {"config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/ut_automata_config.lua", "config/bwibot_config.lua", "config/cobot_config.lua", "config/ut_jackal_config.lua"}
 
 -- init cartesian location of robots
-location_list = {{0.0, 0.0}, {1.0, 0}, {-0.5, -0.866}, {1.0, 0.0}}
+location_list = {{0.0, 0.0}, {0.0, 0.5}, {-0.5, -0.866}, {1.0, 0.0}}
 -- 4 car setting location_list = {{0.0, 0.0}, {-0.5, 0.866}, {-0.5, -0.866}, {1.0, 0.0}}
 
 -- init angle of robots

--- a/config/ut_automata_config.lua
+++ b/config/ut_automata_config.lua
@@ -14,6 +14,6 @@ ak_angular_error_rate = 0.1;
 ak_drive_callback_topic = "/ackermann_curvature_drive"
 
 -- Car configuration
-arkermann_num_segments = 20
-arkermann_radius = 0.05
-arkermann_offset = {0.02, 0} -- position of lidar
+ackermann_num_segments = 20
+ackermann_radius = 0.05
+ackermann_offset = {0.02, 0} -- position of lidar

--- a/config/ut_automata_config.lua
+++ b/config/ut_automata_config.lua
@@ -5,7 +5,7 @@ end
 
 -- Kinematic and dynamic constraints for the car.
 ak_min_turn_radius = 0.98
-ak_max_speed = 1.2
+ak_max_speed = 5.0
 ak_max_accel = 3.0
 
 -- Turning error simulation.

--- a/config/ut_automata_config.lua
+++ b/config/ut_automata_config.lua
@@ -1,6 +1,7 @@
 require("config.sim_config");
 function DegToRad(d)
   return math.pi * d / 180
+end
 
 -- Kinematic and dynamic constraints for the car.
 ak_min_turn_radius = 0.98

--- a/config/ut_automata_config.lua
+++ b/config/ut_automata_config.lua
@@ -1,4 +1,6 @@
 require("config.sim_config");
+function DegToRad(d)
+  return math.pi * d / 180
 
 -- Kinematic and dynamic constraints for the car.
 ak_min_turn_radius = 0.98
@@ -10,3 +12,8 @@ ak_angular_error_bias = DegToRad(0);
 ak_angular_error_rate = 0.1;
 
 ak_drive_callback_topic = "/ackermann_curvature_drive"
+
+-- Car configuration
+arkermann_num_segments = 20
+arkermann_radius = 0.05
+arkermann_offset = {0.02, 0} -- position of lidar

--- a/manifest.xml
+++ b/manifest.xml
@@ -10,4 +10,5 @@
   <depend package="nav_msgs"/>
   <depend package="sensor_msgs"/>
   <depend package="tf"/>
+  <depend package="amrl_msgs"/>
 </package>

--- a/src/simulator/ackermann_model.cpp
+++ b/src/simulator/ackermann_model.cpp
@@ -3,6 +3,7 @@
 #include "shared/math/math_util.h"
 #include <eigen3/Eigen/src/Geometry/Rotation2D.h>
 #include <string>
+
 using Eigen::Vector2f;
 using Eigen::Rotation2Df;
 using ut_multirobot_sim::AckermannCurvatureDriveMsg;
@@ -21,16 +22,12 @@ CONFIG_FLOAT(max_speed, "ak_max_speed");
 CONFIG_FLOAT(angular_bias, "ak_angular_error_bias");
 CONFIG_FLOAT(angular_error, "ak_angular_error_rate");
 CONFIG_STRING(drive_topic, "ak_drive_callback_topic");
-CONFIG_FLOAT(radius, "arkermann_radius");
-CONFIG_FLOAT(num_segments, "arkermann_num_segments");
-CONFIG_VECTOR2F(offset_vec, "arkermann_offset");
+CONFIG_FLOAT(radius, "ackermann_radius");
+CONFIG_FLOAT(num_segments, "ackermann_num_segments");
+CONFIG_VECTOR2F(offset_vec, "ackermann_offset");
 
-AckermannModel::AckermannModel(const vector<string> &config_file,
-                               ros::NodeHandle *n):
-    AckermannModel(config_file, n, ""){
-}
 
-AckermannModel::AckermannModel(const vector<string>& config_file, ros::NodeHandle* n, string topic_prefix) :
+AckermannModel::AckermannModel(const vector<string>& config_file, ros::NodeHandle* n, string topic_prefix = "") :
     RobotModel(),
     last_cmd_(),
     t_last_cmd_(0),
@@ -126,11 +123,10 @@ void AckermannModel::SetTemplateLines(const float r, const int num_segments){
   Eigen::Vector2f v0(r, 0.);
   Eigen::Vector2f v1;
   Eigen::Vector2f offset_vec = CONFIG_offset_vec;
-  const float eps = 0.0005; // lets see if this causes this issue.
+  const float eps = 0.0005;
   for (int i = 1; i < num_segments; i++) {
     v1 = Eigen::Rotation2Df(angle_increment * i) * Eigen::Vector2f(r, 0.0);
 
-    // TODO(yifeng): Fix the vector map bug that closed shape would have wrong occlusion
     Eigen::Vector2f eps_vec = (v1 - v0).normalized() * eps;
     template_lines_.push_back(geometry::Line2f(v0 + eps_vec + offset_vec, v1 - eps_vec + offset_vec));
     v0 = v1;

--- a/src/simulator/ackermann_model.cpp
+++ b/src/simulator/ackermann_model.cpp
@@ -236,12 +236,12 @@ void AckermannModel::Step(const double &dt) {
   //vel_.translation.x() = (vel == 0 && bounded_dv < 0.075)?0:(vel + bounded_dv);
   vel_.translation.x() = vel + bounded_dv;
   const float dist = vel_.translation.x() * dt;
-
   Vector2f d_vector(0,0);
   float dtheta = 0;
   if (linear_motion) {
     d_vector.x() = dist;
     dtheta = dt * CONFIG_angular_bias;
+    vel_.angle = 0;
   } else {
     const float r = 1.0 / desired_curvature;
     dtheta = dist * desired_curvature +
@@ -249,7 +249,10 @@ void AckermannModel::Step(const double &dt) {
         angular_error_(rng_) * CONFIG_angular_error * fabs(dist *
             desired_curvature);
     d_vector = {r * sin(dtheta), r * (1.0 - cos(dtheta))};
+    // update steering angle
+    vel_.angle = vel_.translation.x()/r;
   }
+  
   // Update the Pose
   pose_.translation += Eigen::Rotation2Df(pose_.angle) * d_vector;
   pose_.angle = AngleMod(pose_.angle + dtheta);

--- a/src/simulator/ackermann_model.cpp
+++ b/src/simulator/ackermann_model.cpp
@@ -2,7 +2,7 @@
 #include "shared/util/timer.h"
 #include "shared/math/math_util.h"
 #include <eigen3/Eigen/src/Geometry/Rotation2D.h>
-
+#include <string>
 using Eigen::Vector2f;
 using Eigen::Rotation2Df;
 using ut_multirobot_sim::AckermannCurvatureDriveMsg;
@@ -21,8 +21,16 @@ CONFIG_FLOAT(max_speed, "ak_max_speed");
 CONFIG_FLOAT(angular_bias, "ak_angular_error_bias");
 CONFIG_FLOAT(angular_error, "ak_angular_error_rate");
 CONFIG_STRING(drive_topic, "ak_drive_callback_topic");
+CONFIG_FLOAT(radius, "arkermann_radius");
+CONFIG_FLOAT(num_segments, "arkermann_num_segments");
+CONFIG_VECTOR2F(offset_vec, "arkermann_offset");
 
-AckermannModel::AckermannModel(const vector<string>& config_file, ros::NodeHandle* n) :
+AckermannModel::AckermannModel(const vector<string> &config_file,
+                               ros::NodeHandle *n):
+    AckermannModel(config_file, n, ""){
+}
+
+AckermannModel::AckermannModel(const vector<string>& config_file, ros::NodeHandle* n, string topic_prefix) :
     RobotModel(),
     last_cmd_(),
     t_last_cmd_(0),
@@ -32,10 +40,12 @@ AckermannModel::AckermannModel(const vector<string>& config_file, ros::NodeHandl
   last_cmd_.velocity = 0;
   last_cmd_.curvature = 0;
   drive_subscriber_ = n->subscribe(
-      CONFIG_drive_topic,
+      topic_prefix + CONFIG_drive_topic,
       1,
       &AckermannModel::DriveCallback,
       this);
+  this->SetTemplateLines(CONFIG_radius, CONFIG_num_segments);
+  this->Transform();
 }
 
 void AckermannModel::DriveCallback(const AckermannCurvatureDriveMsg& msg) {
@@ -93,6 +103,39 @@ void AckermannModel::Step(const double &dt) {
   // Update the Pose
   pose_.translation += Eigen::Rotation2Df(pose_.angle) * d_vector;
   pose_.angle = AngleMod(pose_.angle + dtheta);
+  this->Transform();
 }
 
+void AckermannModel::Transform() {
+  Eigen::Rotation2Df R(math_util::AngleMod(pose_.angle));
+  Eigen::Vector2f T = pose_.translation;
+
+  for (size_t i=0; i < template_lines_.size(); i++) {
+    pose_lines_[i].p0 = R * (template_lines_[i].p0) + T;
+    pose_lines_[i].p1 = R * (template_lines_[i].p1) + T;
+  }
+}
+
+void AckermannModel::SetTemplateLines(const float r, const int num_segments){
+  // copied directly from human model. In future refractor the code to 
+  // enable inherentance might be more optimal. For now there is an excessive
+  // amount of unwanted code in HumanModel, which disables inherenting directly.
+
+  const float angle_increment = 2 * M_PI / num_segments;
+
+  Eigen::Vector2f v0(r, 0.);
+  Eigen::Vector2f v1;
+  Eigen::Vector2f offset_vec = CONFIG_offset_vec;
+  const float eps = 0.0005; // lets see if this causes this issue.
+  for (int i = 1; i < num_segments; i++) {
+    v1 = Eigen::Rotation2Df(angle_increment * i) * Eigen::Vector2f(r, 0.0);
+
+    // TODO(yifeng): Fix the vector map bug that closed shape would have wrong occlusion
+    Eigen::Vector2f eps_vec = (v1 - v0).normalized() * eps;
+    template_lines_.push_back(geometry::Line2f(v0 + eps_vec + offset_vec, v1 - eps_vec + offset_vec));
+    v0 = v1;
+  }
+  template_lines_.push_back(geometry::Line2f(v1, Eigen::Vector2f(r, 0.0)));
+  pose_lines_ = template_lines_;
+}
 } // namespace ackermann

--- a/src/simulator/ackermann_model.cpp
+++ b/src/simulator/ackermann_model.cpp
@@ -6,7 +6,11 @@
 
 using Eigen::Vector2f;
 using Eigen::Rotation2Df;
-using ut_multirobot_sim::AckermannCurvatureDriveMsg;
+#ifdef AMRL_MSGS
+  using amrl_msgs::AckermannCurvatureDriveMsg;
+#else
+  using ut_multirobot_sim::AckermannCurvatureDriveMsg;
+#endif
 using math_util::Bound;
 using math_util::AngleDiff;
 using math_util::AngleMod;

--- a/src/simulator/ackermann_model.cpp
+++ b/src/simulator/ackermann_model.cpp
@@ -78,6 +78,7 @@ void AckermannModel::DriveCallback(const AckermannCurvatureDriveMsg& msg) {
   t_last_cmd_ = GetMonotonicTime();
   recieved_cmd_ = true;
   // closed loop simulation only
+  #ifdef CLOSE_LOOP
   if(closed_loop_){
     // push command onto queue
     //std::cout << "last recieved cmd is" << msg.issue_time << std::endl;
@@ -85,6 +86,7 @@ void AckermannModel::DriveCallback(const AckermannCurvatureDriveMsg& msg) {
     cmd_queue.push_back(cmd);
     t_last_cmd_ = msg.issue_time;
   }
+  #endif
 }
 
 void AckermannModel::clearRecieved(){
@@ -235,6 +237,7 @@ void AckermannModel::Step(const double &dt) {
   // Set velocity
   //vel_.translation.x() = (vel == 0 && bounded_dv < 0.075)?0:(vel + bounded_dv);
   vel_.translation.x() = vel + bounded_dv;
+  vel_.angle = vel*desired_curvature;
   const float dist = vel_.translation.x() * dt;
   Vector2f d_vector(0,0);
   float dtheta = 0;
@@ -318,6 +321,10 @@ Pose2Df AckermannModel::GetVel() {
     return s.vel_;
   }
   return vel_;
+}
+
+double AckermannModel::GetAngVel() {
+  return ((vel_.translation.x() >=0) ? 1 : -1)*vel_.translation.norm()*last_cmd_.curvature;
 }
 
 void AckermannModel::SetTemplateLines(const float r, const int num_segments){

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -31,8 +31,8 @@ struct AckermannState{
 
 class AckermannModel : public robot_model::RobotModel {
   const bool closed_loop_ = true;
-  const double t_act_delay_ = 0.0;
-  const double t_obs_delay_ = 0.6;
+  const double t_act_delay_ = 0.01;
+  const double t_obs_delay_ = 0.01;
   const double DT = 0.05;
  private:
   #ifdef AMRL_MSGS

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -28,8 +28,6 @@ class AckermannModel : public robot_model::RobotModel {
   AckermannModel() = delete;
   // Intialize a default object reading from a file
   AckermannModel(const std::vector<std::string> &config_file,
-                 ros::NodeHandle *n);
-  AckermannModel(const std::vector<std::string> &config_file,
                  ros::NodeHandle *n, std::string prefix);
   ~AckermannModel() = default;
   // define Step function for updating

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -30,9 +30,9 @@ struct AckermannState{
 };
 
 class AckermannModel : public robot_model::RobotModel {
-  const bool closed_loop_ = true;
-  const double t_act_delay_ = 0.00;
-  const double t_obs_delay_ = 0.00;
+  const bool closed_loop_ = false;
+  const double t_act_delay_ = 0.0;
+  const double t_obs_delay_ = 0.0;
   //const double DT = 0.05;
  private:
   #ifdef AMRL_MSGS

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -30,9 +30,9 @@ struct AckermannState{
 };
 
 class AckermannModel : public robot_model::RobotModel {
-  const bool closed_loop_ = false;
-  const double t_act_delay_ = 0.01;
-  const double t_obs_delay_ = 0.01;
+  const bool closed_loop_ = true;
+  const double t_act_delay_ = 0.00;
+  const double t_obs_delay_ = 0.00;
   //const double DT = 0.05;
  private:
   #ifdef AMRL_MSGS
@@ -69,15 +69,16 @@ class AckermannModel : public robot_model::RobotModel {
   // define Step function for updating
   void Step(const double &dt);
   // simulated step
-  void SStep(double dt);
+  void SStep(double dt, const double& cur_time);
   void clearRecieved();
-  bool isRecieved();
+  bool isRecieved(const double dt);
   void updateLastCmd();
   AckermannState getState(const double t);
   pose_2d::Pose2Df GetVel() override;
   pose_2d::Pose2Df GetPose() override;
 
   AckermannCmd getCmd(const double& t);
+  void SetPose(const Pose2Df& pose) override;
 };
 
 }  // namespace ackermann

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -24,15 +24,15 @@ struct AckermannCmd{
 };
 
 struct AckermannState{
-  Eigen::Vector2f pose_;
-  double angle_;
-  Eigen::Vector2f vel_;
+  double t_;
+  pose_2d::Pose2Df pose_;
+  pose_2d::Pose2Df vel_;
 };
 
 class AckermannModel : public robot_model::RobotModel {
   const bool closed_loop_ = true;
-  const double t_act_delay_ = 0.5;
-  const double t_obs_delay_ = 0.0;
+  const double t_act_delay_ = 0.0;
+  const double t_obs_delay_ = 0.6;
   const double DT = 0.05;
  private:
   #ifdef AMRL_MSGS
@@ -73,6 +73,10 @@ class AckermannModel : public robot_model::RobotModel {
   void clearRecieved();
   bool isRecieved();
   void updateLastCmd();
+  AckermannState getState(const double t);
+  pose_2d::Pose2Df GetVel() override;
+  pose_2d::Pose2Df GetPose() override;
+
   AckermannCmd getCmd(const double& t);
 };
 

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -30,7 +30,7 @@ struct AckermannState{
 };
 
 class AckermannModel : public robot_model::RobotModel {
-  const bool closed_loop_ = true;
+  const bool closed_loop_ = false;
   const double t_act_delay_ = 0.01;
   const double t_obs_delay_ = 0.01;
   const double DT = 0.05;

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -1,7 +1,14 @@
+// comment out to use ut_multirobot_sim's message.
+#define AMRL_MSGS
+
 #include <random>
 #include <string>
 #include "config_reader/config_reader.h"
-#include "ut_multirobot_sim/AckermannCurvatureDriveMsg.h"
+#ifdef AMRL_MSGS
+  #include "amrl_msgs/AckermannCurvatureDriveMsg.h"
+#else
+  #include "ut_multirobot_sim/AckermannCurvatureDriveMsg.h"
+#endif
 #include "ros/ros.h"
 #include "simulator/robot_model.h"
 
@@ -12,7 +19,11 @@ namespace ackermann {
 
 class AckermannModel : public robot_model::RobotModel {
  private:
-  ut_multirobot_sim::AckermannCurvatureDriveMsg last_cmd_;
+  #ifdef AMRL_MSGS
+    amrl_msgs::AckermannCurvatureDriveMsg last_cmd_;
+  #else
+    ut_multirobot_sim::AckermannCurvatureDriveMsg last_cmd_;
+  #endif
   double t_last_cmd_;
   std::default_random_engine rng_;
   std::normal_distribution<float> angular_error_;
@@ -20,7 +31,11 @@ class AckermannModel : public robot_model::RobotModel {
   config_reader::ConfigReader config_reader_;
 
   // Receives drive callback messages and stores them
-  void DriveCallback(const ut_multirobot_sim::AckermannCurvatureDriveMsg &msg);
+  #ifdef AMRL_MSGS
+    void DriveCallback(const amrl_msgs::AckermannCurvatureDriveMsg &msg);
+  #else
+    void DriveCallback(const ut_multirobot_sim::AckermannCurvatureDriveMsg &msg);
+  #endif
   // Initialize associated template lines (shape of robot)
   void SetTemplateLines(const float r, const int num_segments);
   void Transform();

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -21,12 +21,16 @@ class AckermannModel : public robot_model::RobotModel {
 
   // Receives drive callback messages and stores them
   void DriveCallback(const ut_multirobot_sim::AckermannCurvatureDriveMsg &msg);
-
+  // Initialize associated template lines (shape of robot)
+  void SetTemplateLines(const float r, const int num_segments);
+  void Transform();
  public:
   AckermannModel() = delete;
   // Intialize a default object reading from a file
   AckermannModel(const std::vector<std::string> &config_file,
                  ros::NodeHandle *n);
+  AckermannModel(const std::vector<std::string> &config_file,
+                 ros::NodeHandle *n, std::string prefix);
   ~AckermannModel() = default;
   // define Step function for updating
   void Step(const double &dt);

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -33,7 +33,7 @@ class AckermannModel : public robot_model::RobotModel {
   const bool closed_loop_ = false;
   const double t_act_delay_ = 0.01;
   const double t_obs_delay_ = 0.01;
-  const double DT = 0.05;
+  //const double DT = 0.05;
  private:
   #ifdef AMRL_MSGS
     amrl_msgs::AckermannCurvatureDriveMsg last_cmd_;

--- a/src/simulator/ackermann_model.h
+++ b/src/simulator/ackermann_model.h
@@ -33,6 +33,7 @@ class AckermannModel : public robot_model::RobotModel {
   const bool closed_loop_ = false;
   const double t_act_delay_ = 0.0;
   const double t_obs_delay_ = 0.0;
+
   //const double DT = 0.05;
  private:
   #ifdef AMRL_MSGS
@@ -79,6 +80,7 @@ class AckermannModel : public robot_model::RobotModel {
 
   AckermannCmd getCmd(const double& t);
   void SetPose(const Pose2Df& pose) override;
+  double GetAngVel() override;
 };
 
 }  // namespace ackermann

--- a/src/simulator/diff_drive_model.cpp
+++ b/src/simulator/diff_drive_model.cpp
@@ -78,6 +78,13 @@ DiffDriveModel::DiffDriveModel(const vector<string>& config_files, ros::NodeHand
 
 }
 
+void DiffDriveModel::clearRecieved(){
+}
+
+bool DiffDriveModel::isRecieved(){
+  return false;
+}
+
 void DiffDriveModel::Step(const double &dt) {
     ros::Time current_time = ros::Time::now();
     // Update the linear velocity based on the linear acceleration limits

--- a/src/simulator/diff_drive_model.h
+++ b/src/simulator/diff_drive_model.h
@@ -43,6 +43,8 @@ class DiffDriveModel : public robot_model::RobotModel {
   // define Step function for updating
   void Step(const double& dt);
   void PublishOdom(const float dt);
+    void clearRecieved();
+  bool isRecieved();
 };
 
 } // namespace diffdrive

--- a/src/simulator/omnidirectional_model.cpp
+++ b/src/simulator/omnidirectional_model.cpp
@@ -53,6 +53,13 @@ OmnidirectionalModel::OmnidirectionalModel(const vector<string>& config_files, r
   this->Transform();
 }
 
+void OmnidirectionalModel::clearRecieved(){
+}
+
+bool OmnidirectionalModel::isRecieved(){
+  return false;
+}
+
 void OmnidirectionalModel::DriveCallback(const CobotDriveMsg& msg) {
   if (!isfinite(msg.velocity_x) ||
       !isfinite(msg.velocity_y) ||

--- a/src/simulator/omnidirectional_model.h
+++ b/src/simulator/omnidirectional_model.h
@@ -21,14 +21,17 @@ class OmnidirectionalModel : public robot_model::RobotModel {
   config_reader::ConfigReader config_reader_;
   ros::Publisher odom_publisher_;
 
-  // Receives drive callback messages and stores them
+  // Receives drive callback messages and stores Line2f
   void DriveCallback(const ut_multirobot_sim::CobotDriveMsg& msg);
+  // Initialize associated template lines (shape of robot)
+  void SetTemplateLines(const float r, const int num_segments);
+  void Transform();
 
  public:
   OmnidirectionalModel() = delete;
   // Intialize a default object reading from a file
   OmnidirectionalModel(
-      const std::vector<std::string>& config_files, ros::NodeHandle* n);
+      const std::vector<std::string>& config_files, ros::NodeHandle* n, std::string topic_prefix);
   ~OmnidirectionalModel() = default;
   // define Step function for updating
   void Step(const double& dt);

--- a/src/simulator/omnidirectional_model.h
+++ b/src/simulator/omnidirectional_model.h
@@ -36,6 +36,8 @@ class OmnidirectionalModel : public robot_model::RobotModel {
   // define Step function for updating
   void Step(const double& dt);
   void PublishOdom(const float dt);
+  void clearRecieved();
+  bool isRecieved();
 };
 
 }  // namespace omnidrive

--- a/src/simulator/robot_model.cpp
+++ b/src/simulator/robot_model.cpp
@@ -36,4 +36,13 @@ Pose2Df RobotModel::GetVel() {
   return vel_;
 }
 
+void RobotModel::clearRecieved(){
+}
+
+bool RobotModel::isRecieved(){
+  return false;
+}
+double RobotModel::getClosedLoopTime(){
+  return closed_loop_time_;
+}
 }

--- a/src/simulator/robot_model.cpp
+++ b/src/simulator/robot_model.cpp
@@ -39,7 +39,7 @@ Pose2Df RobotModel::GetVel() {
 void RobotModel::clearRecieved(){
 }
 
-bool RobotModel::isRecieved(){
+bool RobotModel::isRecieved(const double dt){
   return false;
 }
 double RobotModel::getClosedLoopTime(){

--- a/src/simulator/robot_model.cpp
+++ b/src/simulator/robot_model.cpp
@@ -45,4 +45,7 @@ bool RobotModel::isRecieved(const double dt){
 double RobotModel::getClosedLoopTime(){
   return closed_loop_time_;
 }
+double RobotModel::GetAngVel(){
+  return 0;
+}
 }

--- a/src/simulator/robot_model.h
+++ b/src/simulator/robot_model.h
@@ -37,7 +37,7 @@ class RobotModel : public EntityBase {
   virtual void SetVel(const pose_2d::Pose2Df& vel);
   virtual pose_2d::Pose2Df GetVel();
   // check if a command is recieved - closed loop sim
-  virtual bool isRecieved();
+  virtual bool isRecieved(const double dt);
   virtual void clearRecieved();
   virtual double getClosedLoopTime();
 };

--- a/src/simulator/robot_model.h
+++ b/src/simulator/robot_model.h
@@ -29,12 +29,17 @@ namespace robot_model {
 class RobotModel : public EntityBase {
  protected:
   Pose2Df vel_;
+  double closed_loop_time_ = 0;
 
  public:
   RobotModel();
   virtual ~RobotModel() = default;
   virtual void SetVel(const pose_2d::Pose2Df& vel);
   virtual pose_2d::Pose2Df GetVel();
+  // check if a command is recieved - closed loop sim
+  virtual bool isRecieved();
+  virtual void clearRecieved();
+  virtual double getClosedLoopTime();
 };
 }  // namespace robot_model
 

--- a/src/simulator/robot_model.h
+++ b/src/simulator/robot_model.h
@@ -40,6 +40,7 @@ class RobotModel : public EntityBase {
   virtual bool isRecieved(const double dt);
   virtual void clearRecieved();
   virtual double getClosedLoopTime();
+  virtual double GetAngVel();
 };
 }  // namespace robot_model
 

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -121,6 +121,7 @@ Simulator::Simulator(const std::string& sim_config) :
   truePoseMsg_.header.frame_id = "map";
   // initialize object lines associated with each robot
   motion_models_lines_.resize(robot_number_, std::vector<Line2f>(0));
+  sim_time_ = 0.0;
 }
 
 Simulator::~Simulator() {}
@@ -636,11 +637,11 @@ string GetMapNameFromFilename(string path) {
 
 void Simulator::Run() {
   
-  const bool closed_loop = false;
+  const bool closed_loop = true;
   if(closed_loop){
     bool all_recieved = true;
     for(const auto& m: motion_models_){
-      if(!m->isRecieved()){
+      if(!m->isRecieved(sim_time_)){
         all_recieved = false;
       }
     }
@@ -670,6 +671,7 @@ void Simulator::Run() {
           localizationMsg_.pose.y = cur_loc_.translation.y();
           localizationMsg_.pose.theta = cur_loc_.angle;
           localizationMsg_.issue_time = motion_models_[i]->getClosedLoopTime();
+          cout << "current sim time is " << sim_time_ << " issue time is " << motion_models_[i]->getClosedLoopTime() << "state is" <<  localizationMsg_.pose.x << std::endl;
           localizationPublishers_[i].publish(localizationMsg_);
       }
     }
@@ -677,6 +679,8 @@ void Simulator::Run() {
       for(const auto& m : motion_models_){
         m->clearRecieved();
       }
+      sim_time_ += CONFIG_DT;
+      cout << "current sim time is " << sim_time_ << std::endl;
     }
   }
   else{

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -637,7 +637,7 @@ string GetMapNameFromFilename(string path) {
 
 void Simulator::Run() {
   
-  const bool closed_loop = true;
+  const bool closed_loop = false;
   if(closed_loop){
     bool all_recieved = true;
     for(const auto& m: motion_models_){

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -636,7 +636,7 @@ string GetMapNameFromFilename(string path) {
 
 void Simulator::Run() {
   
-  const bool closed_loop = true;
+  const bool closed_loop = false;
   if(closed_loop){
     bool all_recieved = true;
     for(const auto& m: motion_models_){

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -48,8 +48,6 @@
 
 DEFINE_bool(localize, false, "Publish localization");
 
-using ackermann::AckermannModel;
-using cobot::CobotModel;
 using Eigen::Rotation2Df;
 using Eigen::Vector2f;
 using Eigen::Vector3f;
@@ -145,10 +143,10 @@ bool Simulator::init(ros::NodeHandle& n) {
       motion_models_.push_back(unique_ptr<AckermannModel>(
           new AckermannModel({CONFIG_robot_configs[i]}, &n, topic_prefix)));
     } else if (robot_type == "OMNIDIRECTIONAL_DRIVE"){
-      motion_models_.push_back(unique_ptr<CobotModel>(
+      motion_models_.push_back(unique_ptr<OmnidirectionalModel>(
           new OmnidirectionalModel({CONFIG_robot_configs[i]}, &n, topic_prefix)));
     }
-    else if (robot_type == "BWIBOT") {
+    else if (robot_type == "DIFF_DRIVE") {
       if(robot_number_ != 1){
         std::logic_error("Warning, Diff Drive Currently does not support multiple robots\n");
       }
@@ -156,9 +154,9 @@ bool Simulator::init(ros::NodeHandle& n) {
           new DiffDriveModel({CONFIG_robot_configs[i]}, &n)));
     }
     else{
-    std::cerr << "Robot type \"" << robot_type
-              << "\" has no associated motion model!" << std::endl;
-    return false;
+      std::cerr << "Robot type \"" << robot_type
+                << "\" has no associated motion model!" << std::endl;
+      return false;
     }
     // initialize starting location
     cur_locs_.push_back(
@@ -257,7 +255,7 @@ void Simulator::loadObject() {
   }
 }
 
-// TODO: figure out higher order function
+// TODO(Tongrui Li): figure out higher order function
 void Simulator::InitalLocationCallbackMulti(const PoseWithCovarianceStamped& msg, int robot_num) {
   const Vector2f loc =
       Vector2f(msg.pose.pose.position.x, msg.pose.pose.position.y);

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -24,7 +24,9 @@
 #include <memory>
 #include <stdio.h>
 
+#include <iterator>
 #include <random>
+#include <string>
 
 #include "eigen3/Eigen/Dense"
 #include "eigen3/Eigen/Geometry"
@@ -46,8 +48,11 @@
 
 DEFINE_bool(localize, false, "Publish localization");
 
+using ackermann::AckermannModel;
+using cobot::CobotModel;
 using Eigen::Rotation2Df;
 using Eigen::Vector2f;
+using Eigen::Vector3f;
 using geometry::Heading;
 using geometry::Line2f;
 using geometry_msgs::PoseWithCovarianceStamped;
@@ -80,16 +85,19 @@ CONFIG_BOOL(publish_map_to_odom, "publish_map_to_odom");
 CONFIG_BOOL(publish_foot_to_base, "publish_foot_to_base");
 
 // Used for topic names and robot specs
-CONFIG_STRING(robot_type, "robot_type");
-CONFIG_STRING(robot_config, "robot_config");
+CONFIG_STRINGLIST(robot_types, "type_list");
+CONFIG_STRINGLIST(robot_configs, "config_list");
 CONFIG_STRING(laser_topic, "laser_topic");
 CONFIG_STRING(laser_frame, "laser_frame");
+CONFIG_VECTOR3FLIST(robot_colors, "RGB_list");
+CONFIG_INT(robot_number, "robot_number");
+CONFIG_STRINGLIST(topic_prefixs, "topic_prefix_list");
 
 CONFIG_STRING(map_name, "map_name");
-// Initial location
-CONFIG_FLOAT(start_x, "start_x");
-CONFIG_FLOAT(start_y, "start_y");
-CONFIG_FLOAT(start_angle, "start_angle");
+// Initial location and angles
+CONFIG_VECTOR2FLIST(robot_start_locations, "location_list");
+CONFIG_DOUBLELIST(robot_start_angles, "angle_list");
+
 CONFIG_STRINGLIST(short_term_object_config_list, "short_term_object_config_list");
 CONFIG_STRINGLIST(human_config_list, "human_config_list");
 
@@ -102,12 +110,17 @@ Simulator::Simulator(const std::string& sim_config) :
     vel_(0, {0,0}),
     cur_loc_(0, {0,0}),
     laser_noise_(0, 1),
-    robot_type_(CONFIG_robot_type) {
+    robot_number_(CONFIG_robot_number),
+    topic_prefixs_(CONFIG_topic_prefixs),
+    robot_types_(CONFIG_robot_types){
   truePoseMsg.header.seq = 0;
   truePoseMsg.header.frame_id = "map";
+  // TODO: add static cast robot_type_(static_cast<RobotType>(CONFIG_robot_type))
+  // initialize object lines associated with each robot
+  motion_models_lines_.resize(robot_number_, std::vector<Line2f>(0));
 }
 
-Simulator::~Simulator() { }
+Simulator::~Simulator() {}
 
 bool Simulator::init(ros::NodeHandle& n) {
   // TODO(jaholtz) Too much hard coding, move to config
@@ -126,55 +139,111 @@ bool Simulator::init(ros::NodeHandle& n) {
   odometryTwistMsg.header.frame_id = "odom";
   odometryTwistMsg.child_frame_id = "base_footprint";
 
-  cur_loc_ = Pose2Df(CONFIG_start_angle, {CONFIG_start_x, CONFIG_start_y});
-
-  // Create motion model based on robot type
-  // TODO extend to handle the multi-robot case
-  if (robot_type_ == "ACKERMANN_DRIVE") {
-    motion_model_ = unique_ptr<AckermannModel>(
-        new AckermannModel({CONFIG_robot_config}, &n));
-  } else if (robot_type_ == "OMNIDIRECTIONAL_DRIVE") {
-    motion_model_ = unique_ptr<OmnidirectionalModel>(
-        new OmnidirectionalModel({CONFIG_robot_config}, &n));
-  } else if (robot_type_ == "DIFF_DRIVE") {
-    motion_model_ = unique_ptr<DiffDriveModel>(
-        new DiffDriveModel({CONFIG_robot_config}, &n));
-  }
-
-  if (motion_model_ == nullptr) {
-    std::cerr << "Robot type \"" << robot_type_
+  for (int i = 0; i < robot_number_; i++) {
+    string robot_type = robot_types_[i];
+    string topic_prefix = topic_prefixs_[i];
+    if (robot_type == "ACKERMANN_DRIVE") {
+      motion_models_.push_back(unique_ptr<AckermannModel>(
+          new AckermannModel({CONFIG_robot_configs[i]}, &n, topic_prefix)));
+    } else if (robot_type == "OMNIDIRECTIONAL_DRIVE"){
+      motion_models_.push_back(unique_ptr<CobotModel>(
+          new OmnidirectionalModel({CONFIG_robot_configs[i]}, &n, topic_prefix)));
+    }
+    else if (robot_type == "BWIBOT") {
+      if(robot_number_ != 1){
+        printf("Warning, Diff Drive Currently does not support multiple robots\n");
+      }
+      motion_models_.push_back(unique_ptr<DiffDriveModel>(
+          new DiffDriveModel({CONFIG_robot_configs[i]}, &n)));
+    }
+    else{
+    std::cerr << "Robot type \"" << robot_type
               << "\" has no associated motion model!" << std::endl;
     return false;
+    }
+    // initialize starting location
+    cur_locs_.push_back(
+        Pose2Df(CONFIG_robot_start_angles[i], CONFIG_robot_start_locations[i]));
+    motion_models_[i]->SetPose(cur_locs_[i]);
   }
 
-  motion_model_->SetPose(cur_loc_);
-  initSimulatorVizMarkers();
+  initSimulatorVizMarkers(); // TODO: need to add a vis marker for every robot
   drawMap();
 
-  initSubscriber = n.subscribe(
-      "/initialpose", 1, &Simulator::InitalLocationCallback, this);
-  odometryTwistPublisher = n.advertise<nav_msgs::Odometry>("/odom",1);
-  laserPublisher = n.advertise<sensor_msgs::LaserScan>(CONFIG_laser_topic, 1);
-  viz_laser_publisher_ = n.advertise<sensor_msgs::LaserScan>("/scan", 1);
-  mapLinesPublisher = n.advertise<visualization_msgs::Marker>(
-      "/simulator_visualization", 6);
+  // Initialize topics for each robot
+  for(int i = 0; i < robot_number_; i++){
+    string topic_prefix = topic_prefixs_[i];
+    printf("[%d] topic_prefix: %s\n", i, topic_prefix.c_str());
+    // TODO: Change this hardcoding to something nicer
+        odometryTwistPublishers.push_back(
+        n.advertise<nav_msgs::Odometry>(topic_prefix + "/odom", 1));
+    laserPublishers.push_back(n.advertise<sensor_msgs::LaserScan>(
+        topic_prefix + CONFIG_laser_topic, 1));
+    viz_laser_publishers_.push_back(n.advertise<sensor_msgs::LaserScan>(
+        topic_prefix + "/scan", 1));
+    if (FLAGS_localize) {
+      localizationPublishers.push_back(n.advertise<ut_multirobot_sim::Localization2DMsg>(
+          topic_prefix + "/localization", 1));
+    }
+  }
+  // initialize hard coded initial pose
+  for (int i = 0; i < robot_number_; i++) {
+    if (i == 7) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[7] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar7, this));
+    } else if (i == 6) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[6] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar6, this));
+    } else if (i == 5) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[5] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar5, this));
+    } else if (i == 4) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[4] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar4, this));
+    } else if (i == 3) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[3] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar3, this));
+    } else if (i == 2) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[2] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar2, this));
+    } else if (i == 1) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[1] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar1, this));
+    } else if (i == 0) {
+      initSubscribers.push_back(
+          n.subscribe(topic_prefixs_[0] + "/initialpose", 1,
+                      &Simulator::InitalLocationCallbackCar0, this));
+    }
+  }
+  // initialize topics shared jointly
+  truePosePublisher = n.advertise<geometry_msgs::PoseStamped>(
+        "/simulator_true_pose", 1); 
+
   posMarkerPublisher = n.advertise<visualization_msgs::Marker>(
+      "/simulator_visualization", 6); 
+  mapLinesPublisher = n.advertise<visualization_msgs::Marker>(
       "/simulator_visualization", 6);
   objectLinesPublisher = n.advertise<visualization_msgs::Marker>(
       "/simulator_visualization", 6);
-  truePosePublisher = n.advertise<geometry_msgs::PoseStamped>(
-      "/simulator_true_pose", 1);
   if (FLAGS_localize) {
-    localizationPublisher = n.advertise<ut_multirobot_sim::Localization2DMsg>(
-        "/localization", 1);
     localizationMsg.header.frame_id = "map";
     localizationMsg.header.seq = 0;
   }
+
+
   br = new tf::TransformBroadcaster();
 
   this->loadObject();
   return true;
 }
+
 
 // TODO(yifeng): Change this into a general way
 void Simulator::loadObject() {
@@ -190,7 +259,8 @@ void Simulator::loadObject() {
   }
 }
 
-void Simulator::InitalLocationCallback(const PoseWithCovarianceStamped& msg) {
+// TODO: figure out higher order function
+void Simulator::InitalLocationCallbackMulti(const PoseWithCovarianceStamped& msg, int car_num) {
   const Vector2f loc =
       Vector2f(msg.pose.pose.position.x, msg.pose.pose.position.y);
   const float angle = 2.0 *
@@ -199,7 +269,47 @@ void Simulator::InitalLocationCallback(const PoseWithCovarianceStamped& msg) {
          cur_loc_.translation.x(),
          cur_loc_.translation.y(),
          RadToDeg(cur_loc_.angle));
-  motion_model_->SetPose({angle, loc});
+  motion_models_[car_num]->SetPose({angle, loc}); // TODO, add loop
+}
+
+void Simulator::InitalLocationCallbackCar0(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 0);
+}
+
+void Simulator::InitalLocationCallbackCar1(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 1);
+}
+
+void Simulator::InitalLocationCallbackCar2(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 2);
+}
+
+void Simulator::InitalLocationCallbackCar3(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 3);
+}
+
+void Simulator::InitalLocationCallbackCar4(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 4);
+}
+
+void Simulator::InitalLocationCallbackCar5(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 5);
+}
+
+void Simulator::InitalLocationCallbackCar6(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 6);
+}
+
+void Simulator::InitalLocationCallbackCar7(
+    const PoseWithCovarianceStamped &msg) {
+  InitalLocationCallbackMulti(msg, 7);
 }
 
 /**
@@ -286,12 +396,21 @@ void Simulator::initSimulatorVizMarkers() {
   scale.x = CONFIG_car_length;
   scale.y = CONFIG_car_width;
   scale.z = CONFIG_car_height;
-  color[0] = 94.0 / 255.0;
-  color[1] = 156.0 / 255.0;
-  color[2] = 255.0 / 255.0;
-  color[3] = 0.8;
-  initVizMarker(robotPosMarker, "robot_position", 1, "cube", p, scale, 0.0,
-      color);
+  color[0] = 0;
+  color[1] = 0;
+  color[2] = 0;
+  color[3] = 0.8; // luminosity
+
+  for(int i = 0; i < robot_number_; i++){
+    robotPosMarkers.push_back(visualization_msgs::Marker());
+    color[0] = CONFIG_robot_colors[i].x()/255.0;
+    color[1] = CONFIG_robot_colors[i].y()/255.0;
+    color[2] = CONFIG_robot_colors[i].z()/255.0;
+
+    initVizMarker(robotPosMarkers[i],
+                  "car" + std::to_string(i) + "_robot_position", i + 2, "cube",
+                  p, scale, 0.0, color);
+  }
 
   p.pose.orientation.w = 1.0;
   scale.x = 0.02;
@@ -320,7 +439,7 @@ void Simulator::drawObjects() {
   }
 }
 
-void Simulator::publishOdometry() {
+void Simulator::publishOdometry(int cur_car_number) {
   tf::Quaternion robotQ = tf::createQuaternionFromYaw(cur_loc_.angle);
 
   odometryTwistMsg.header.stamp = ros::Time::now();
@@ -337,29 +456,34 @@ void Simulator::publishOdometry() {
   odometryTwistMsg.twist.twist.linear.x = vel_.translation.x();
   odometryTwistMsg.twist.twist.linear.y = vel_.translation.y();
   odometryTwistMsg.twist.twist.linear.z = 0.0;
+ 
+  odometryTwistMsg.header.frame_id = topic_prefixs_[cur_car_number] + "/odom";
+  odometryTwistMsg.child_frame_id = topic_prefixs_[cur_car_number] + "/base_footprint";
 
-  odometryTwistPublisher.publish(odometryTwistMsg);
+  odometryTwistPublishers[cur_car_number].publish(odometryTwistMsg);
 
   // TODO(jaholtz) visualization should not always be based on car
   // parameters
-  robotPosMarker.pose.position.x =
+  robotPosMarkers[cur_car_number].pose.position.x =
       cur_loc_.translation.x() - cos(cur_loc_.angle) * CONFIG_rear_axle_offset;
-  robotPosMarker.pose.position.y =
+  robotPosMarkers[cur_car_number].pose.position.y =
       cur_loc_.translation.y() - sin(cur_loc_.angle) * CONFIG_rear_axle_offset;
-  robotPosMarker.pose.position.z = 0.5 * CONFIG_car_height;
-  robotPosMarker.pose.orientation.w = 1.0;
-  robotPosMarker.pose.orientation.x = robotQ.x();
-  robotPosMarker.pose.orientation.y = robotQ.y();
-  robotPosMarker.pose.orientation.z = robotQ.z();
-  robotPosMarker.pose.orientation.w = robotQ.w();
+  robotPosMarkers[cur_car_number].pose.position.z = 0.5 * CONFIG_car_height;
+  robotPosMarkers[cur_car_number].pose.orientation.w = 1.0;
+  robotPosMarkers[cur_car_number].pose.orientation.x = robotQ.x();
+  robotPosMarkers[cur_car_number].pose.orientation.y = robotQ.y();
+  robotPosMarkers[cur_car_number].pose.orientation.z = robotQ.z();
+  robotPosMarkers[cur_car_number].pose.orientation.w = robotQ.w();
 }
 
-void Simulator::publishLaser() {
+void Simulator::publishLaser(int cur_car_number) {
   if (map_.file_name != CONFIG_map_name) {
     map_.Load(CONFIG_map_name);
     drawMap();
   }
   scanDataMsg.header.stamp = ros::Time::now();
+  scanDataMsg.header.frame_id = topic_prefixs_[cur_car_number] + "/base_laser";
+
   const Vector2f laserRobotLoc(CONFIG_laser_x, CONFIG_laser_y);
   const Vector2f laserLoc =
       cur_loc_.translation + Rotation2Df(cur_loc_.angle) * laserRobotLoc;
@@ -385,57 +509,66 @@ void Simulator::publishLaser() {
   // TODO Avoid publishing laser twice.
   // Currently publishes once for the visualizer and once for robot
   // requirements.
-  laserPublisher.publish(scanDataMsg);
-  viz_laser_publisher_.publish(scanDataMsg);
+  laserPublishers[cur_car_number].publish(scanDataMsg);
+  viz_laser_publishers_[cur_car_number].publish(scanDataMsg);
 }
 
-void Simulator::publishTransform() {
+void Simulator::publishTransform(int cur_car_number) {
   if (!CONFIG_publish_tfs) {
     return;
   }
+
   tf::Transform transform;
   tf::Quaternion q;
 
+  string topic_prefix = topic_prefixs_[cur_car_number];
+
   if(CONFIG_publish_map_to_odom) {
-      transform.setOrigin(tf::Vector3(0.0,0.0,0.0));
-      transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
-      br->sendTransform(tf::StampedTransform(transform, ros::Time::now(), "/map",
-      "/odom"));
+    transform.setOrigin(tf::Vector3(0.0,0.0,0.0));
+    transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+    br->sendTransform(tf::StampedTransform(transform, ros::Time::now(), "/map",
+        topic_prefix + "/odom"));
   }
+
   transform.setOrigin(tf::Vector3(cur_loc_.translation.x(),
         cur_loc_.translation.y(), 0.0));
   q.setRPY(0.0, 0.0, cur_loc_.angle);
   transform.setRotation(q);
-  br->sendTransform(tf::StampedTransform(transform, ros::Time::now(), "/odom",
-      "/base_footprint"));
+  br->sendTransform(tf::StampedTransform(transform, ros::Time::now(), topic_prefix + "/odom",
+      topic_prefix + "/base_footprint"));
 
   if(CONFIG_publish_foot_to_base){
-      transform.setOrigin(tf::Vector3(0.0 ,0.0, 0.0));
-      transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
-      br->sendTransform(tf::StampedTransform(transform, ros::Time::now(),
-        "/base_footprint", "/base_link"));
+    transform.setOrigin(tf::Vector3(0.0 ,0.0, 0.0));
+    transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+    br->sendTransform(tf::StampedTransform(transform, ros::Time::now(),
+        topic_prefix + "/base_footprint", topic_prefix + "/base_link"));
   }
 
   transform.setOrigin(tf::Vector3(CONFIG_laser_x,
         CONFIG_laser_y, CONFIG_laser_z));
   transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1));
   br->sendTransform(tf::StampedTransform(transform, ros::Time::now(),
-      "/base_link", "/base_laser"));
+      topic_prefix + "/base_link", topic_prefix + "/base_laser"));
 }
 
-void Simulator::publishVisualizationMarkers() {
+void Simulator::publishVisualizationMarkers(int cur_car_number) {
   mapLinesPublisher.publish(lineListMarker);
-  posMarkerPublisher.publish(robotPosMarker);
+
+  posMarkerPublisher.publish(robotPosMarkers[cur_car_number]);
+
   objectLinesPublisher.publish(objectLinesMarker);
 }
 
-void Simulator::update() {
+void Simulator::updateLocation(int cur_car_number){
   // Step the motion model forward one time step
-  motion_model_->Step(CONFIG_DT);
-
+  motion_models_[cur_car_number]->Step(CONFIG_DT);
   // Update the simulator with the motion model result.
-  cur_loc_ = motion_model_->GetPose();
-  vel_ = motion_model_->GetVel();
+  cur_locs_[cur_car_number] = motion_models_[cur_car_number]->GetPose();
+}
+
+void Simulator::update(int cur_car_number) {
+  cur_loc_ = cur_locs_[cur_car_number];
+  vel_ = motion_models_[cur_car_number]->GetVel();
 
   // Publishing the ground truth pose
   truePoseMsg.header.stamp = ros::Time::now();
@@ -458,6 +591,27 @@ void Simulator::update() {
     }
   }
   this->drawObjects();
+  // update objects associated with each robot
+  for (Line2f line: motion_models_lines_[cur_car_number]){
+      map_.object_lines.push_back(line);    
+  }
+}
+
+void Simulator::updateSimulatorLines(){
+  // Runtime is O(n^2),  but n (number of robot)
+  // is always small, so this is fine.
+  for(int i = 0; i < robot_number_; i++){
+    motion_models_lines_[i].clear();
+  }
+  for(int i = 0; i < robot_number_; i++){
+    for(int j = 0; j < robot_number_; j++){
+      if(i != j){
+        for(Line2f line: motion_models_[j]->GetLines()){
+          motion_models_lines_[i].push_back(line);
+        }
+      }
+    }
+  }
 }
 
 string GetMapNameFromFilename(string path) {
@@ -471,24 +625,34 @@ string GetMapNameFromFilename(string path) {
   return file_name;
 }
 
-void Simulator::Run() {
-  // Simulate time-step.
-  update();
-  //publish odometry and status
-  publishOdometry();
-  //publish laser rangefinder messages
-  publishLaser();
-  // publish visualization marker messages
-  publishVisualizationMarkers();
-  //publish tf
-  publishTransform();
 
-  if (FLAGS_localize) {
-    localizationMsg.header.stamp = ros::Time::now();
-    localizationMsg.map = GetMapNameFromFilename(map_.file_name);
-    localizationMsg.pose.x = cur_loc_.translation.x();
-    localizationMsg.pose.y = cur_loc_.translation.y();
-    localizationMsg.pose.theta = cur_loc_.angle;
-    localizationPublisher.publish(localizationMsg);
+
+void Simulator::Run() {
+  // update the position of the robots
+  for(int i = 0; i < robot_number_; i++){
+    updateLocation(i);
   }
+  // update object lines associated with each robot
+  this->updateSimulatorLines();
+  // publish messages related to the robots
+  for(int i = 0; i < robot_number_; i++){
+    update(i);
+    //publish odometry and status
+    publishOdometry(i); 
+    //publish laser rangefinder messages
+    publishLaser(i);
+    // publish visualization marker messages
+    publishVisualizationMarkers(i);
+    //publish tf
+    publishTransform(i);
+    if (FLAGS_localize) {
+      localizationMsg.header.stamp = ros::Time::now();
+      localizationMsg.map = GetMapNameFromFilename(map_.file_name);
+      localizationMsg.pose.x = cur_loc_.translation.x();
+      localizationMsg.pose.y = cur_loc_.translation.y();
+      localizationMsg.pose.theta = cur_loc_.angle;
+      localizationPublishers[i].publish(localizationMsg);
+    }
+  }
+  
 }

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -18,6 +18,7 @@
 \author  Joydeep Biswas, (C) 2011
 */
 //========================================================================
+#define AMRL_MSGS
 
 #include <libgen.h>
 #include <math.h>
@@ -43,8 +44,13 @@
 #include "shared/math/math_util.h"
 #include "shared/ros/ros_helpers.h"
 #include "shared/util/timer.h"
-#include "ut_multirobot_sim/Localization2DMsg.h"
 #include "vector_map.h"
+
+#ifdef AMRL_MSGS
+  #include "amrl_msgs/Localization2DMsg.h"
+#else
+  #include "ut_multirobot_sim/Localization2DMsg.h"
+#endif
 
 DEFINE_bool(localize, false, "Publish localization");
 
@@ -179,8 +185,13 @@ bool Simulator::init(ros::NodeHandle& n) {
     viz_laser_publishers_.push_back(n.advertise<sensor_msgs::LaserScan>(
         topic_prefix + "/scan", 1));
     if (FLAGS_localize) {
+      #ifdef AMRL_MSGS
+      localizationPublishers_.push_back(n.advertise<amrl_msgs::Localization2DMsg>(
+          topic_prefix + "/localization", 1));
+      #else
       localizationPublishers_.push_back(n.advertise<ut_multirobot_sim::Localization2DMsg>(
           topic_prefix + "/localization", 1));
+      #endif
     }
   }
   // initialize hard coded initial pose

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -670,7 +670,9 @@ void Simulator::Run() {
           localizationMsg_.pose.x = cur_loc_.translation.x();
           localizationMsg_.pose.y = cur_loc_.translation.y();
           localizationMsg_.pose.theta = cur_loc_.angle;
+          #ifdef CLOSE_LOOP
           localizationMsg_.issue_time = motion_models_[i]->getClosedLoopTime();
+          #endif
           cout << "current sim time is " << sim_time_ << " issue time is " << motion_models_[i]->getClosedLoopTime() << "state is" <<  localizationMsg_.pose.x << std::endl;
           localizationPublishers_[i].publish(localizationMsg_);
       }

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -116,6 +116,7 @@ class Simulator {
   std::vector<Pose2Df> cur_locs_;
   // object lines associated with each vector
   std::vector<std::vector<geometry::Line2f>> motion_models_lines_;
+  
  private:
   void initVizMarker(visualization_msgs::Marker &vizMarker, string ns, int id,
                      string type, geometry_msgs::PoseStamped p,

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -66,30 +66,30 @@ class Simulator {
 
   std::vector<std::unique_ptr<EntityBase>> objects;
 
-  std::vector<ros::Subscriber> initSubscribers;
+  std::vector<ros::Subscriber> initSubscribers_;
 
-  std::vector<ros::Publisher> odometryTwistPublishers;
-  std::vector<ros::Publisher> laserPublishers;
+  std::vector<ros::Publisher> odometryTwistPublishers_;
+  std::vector<ros::Publisher> laserPublishers_;
   std::vector<ros::Publisher> viz_laser_publishers_;
-  ros::Publisher mapLinesPublisher;
-  ros::Publisher posMarkerPublisher;
-  ros::Publisher objectLinesPublisher;
-  ros::Publisher truePosePublisher;
-  std::vector<ros::Publisher> localizationPublishers;
-  tf::TransformBroadcaster *br;
+  ros::Publisher mapLinesPublisher_;
+  ros::Publisher posMarkerPublisher_;
+  ros::Publisher objectLinesPublisher_;
+  ros::Publisher truePosePublisher_;
+  std::vector<ros::Publisher> localizationPublishers_;
+  tf::TransformBroadcaster *br_;
 
-  sensor_msgs::LaserScan scanDataMsg;
-  nav_msgs::Odometry odometryTwistMsg;
-  ut_multirobot_sim::Localization2DMsg localizationMsg;
+  sensor_msgs::LaserScan scanDataMsg_;
+  nav_msgs::Odometry odometryTwistMsg_;
+  ut_multirobot_sim::Localization2DMsg localizationMsg_;
 
   vector_map::VectorMap map_;
 
-  visualization_msgs::Marker lineListMarker;
-  visualization_msgs::Marker robotPosMarker;
-  visualization_msgs::Marker objectLinesMarker;
+  visualization_msgs::Marker lineListMarker_;
+  std::vector<visualization_msgs::Marker> robotPosMarkers_;
+  visualization_msgs::Marker objectLinesMarker_;
 
   static const float DT;
-  geometry_msgs::PoseStamped truePoseMsg;
+  geometry_msgs::PoseStamped truePoseMsg_;
 
   std::default_random_engine rng_;
   std::normal_distribution<float> laser_noise_;
@@ -98,7 +98,6 @@ class Simulator {
   std::vector<std::unique_ptr<robot_model::RobotModel>> motion_models_;
   int robot_number_;
   //std::vector<ros::Publisher> truePosePublishers;
-  std::vector<visualization_msgs::Marker> robotPosMarkers;
   // topic prefixes
   std::vector<std::string> topic_prefixs_;
   std::vector<std::string> robot_types_;
@@ -117,34 +116,34 @@ class Simulator {
   void InitalLocationCallback(
       const geometry_msgs::PoseWithCovarianceStamped &msg);
   void DriveCallback(const ut_multirobot_sim::AckermannCurvatureDriveMsg &msg);
-  void publishOdometry(int cur_car_number);
-  void publishLaser(int cur_car_number);
-  void publishVisualizationMarkers(int cur_car_number);
-  void publishTransform(int cur_car_number);
-  void update(int cur_car_number);
-  void updateLocation(int cur_car_number);
+  void publishOdometry(int cur_robot_number);
+  void publishLaser(int cur_robot_number);
+  void publishVisualizationMarkers(int cur_robot_number);
+  void publishTransform(int cur_robot_number);
+  void update(int cur_robot_number);
+  void updateLocation(int cur_robot_number);
   void updateSimulatorLines();
   void loadObject();
 
 
   // TODO: figure out higher order function
   void InitalLocationCallbackMulti(
-    const geometry_msgs::PoseWithCovarianceStamped &msg, int car_num);
-  void InitalLocationCallbackCar0(
+    const geometry_msgs::PoseWithCovarianceStamped &msg, int robot_num);
+  void InitalLocationCallbackRobot0(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void InitalLocationCallbackCar1(
+  void InitalLocationCallbackRobot1(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void InitalLocationCallbackCar2(
+  void InitalLocationCallbackRobot2(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void InitalLocationCallbackCar3(
+  void InitalLocationCallbackRobot3(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void InitalLocationCallbackCar4(
+  void InitalLocationCallbackRobot4(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void InitalLocationCallbackCar5(
+  void InitalLocationCallbackRobot5(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void InitalLocationCallbackCar6(
+  void InitalLocationCallbackRobot6(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void InitalLocationCallbackCar7(
+  void InitalLocationCallbackRobot7(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
 
  public:

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -60,21 +60,22 @@ class Simulator {
   config_reader::ConfigReader reader_;
   config_reader::ConfigReader init_config_reader_;
 
+  // tenporary variables
   Pose2Df vel_;
   Pose2Df cur_loc_;
 
   std::vector<std::unique_ptr<EntityBase>> objects;
 
-  ros::Subscriber initSubscriber;
+  std::vector<ros::Subscriber> initSubscribers;
 
-  ros::Publisher odometryTwistPublisher;
-  ros::Publisher laserPublisher;
-  ros::Publisher viz_laser_publisher_;
+  std::vector<ros::Publisher> odometryTwistPublishers;
+  std::vector<ros::Publisher> laserPublishers;
+  std::vector<ros::Publisher> viz_laser_publishers_;
   ros::Publisher mapLinesPublisher;
   ros::Publisher posMarkerPublisher;
   ros::Publisher objectLinesPublisher;
   ros::Publisher truePosePublisher;
-  ros::Publisher localizationPublisher;
+  std::vector<ros::Publisher> localizationPublishers;
   tf::TransformBroadcaster *br;
 
   sensor_msgs::LaserScan scanDataMsg;
@@ -93,9 +94,18 @@ class Simulator {
   std::default_random_engine rng_;
   std::normal_distribution<float> laser_noise_;
 
-  std::unique_ptr<robot_model::RobotModel> motion_model_;
-  std::string robot_type_;
+  // multi-robot variables
+  std::vector<std::unique_ptr<robot_model::RobotModel>> motion_models_;
+  int robot_number_;
+  //std::vector<ros::Publisher> truePosePublishers;
+  std::vector<visualization_msgs::Marker> robotPosMarkers;
+  // topic prefixes
+  std::vector<std::string> topic_prefixs_;
+  std::vector<std::string> robot_types_;
 
+  std::vector<Pose2Df> cur_locs_;
+  // object lines associated with each vector
+  std::vector<std::vector<geometry::Line2f>> motion_models_lines_;
  private:
   void initVizMarker(visualization_msgs::Marker &vizMarker, string ns, int id,
                      string type, geometry_msgs::PoseStamped p,
@@ -107,12 +117,35 @@ class Simulator {
   void InitalLocationCallback(
       const geometry_msgs::PoseWithCovarianceStamped &msg);
   void DriveCallback(const ut_multirobot_sim::AckermannCurvatureDriveMsg &msg);
-  void publishOdometry();
-  void publishLaser();
-  void publishVisualizationMarkers();
-  void publishTransform();
-  void update();
+  void publishOdometry(int cur_car_number);
+  void publishLaser(int cur_car_number);
+  void publishVisualizationMarkers(int cur_car_number);
+  void publishTransform(int cur_car_number);
+  void update(int cur_car_number);
+  void updateLocation(int cur_car_number);
+  void updateSimulatorLines();
   void loadObject();
+
+
+  // TODO: figure out higher order function
+  void InitalLocationCallbackMulti(
+    const geometry_msgs::PoseWithCovarianceStamped &msg, int car_num);
+  void InitalLocationCallbackCar0(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
+  void InitalLocationCallbackCar1(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
+  void InitalLocationCallbackCar2(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
+  void InitalLocationCallbackCar3(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
+  void InitalLocationCallbackCar4(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
+  void InitalLocationCallbackCar5(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
+  void InitalLocationCallbackCar6(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
+  void InitalLocationCallbackCar7(
+    const geometry_msgs::PoseWithCovarianceStamped &msg);
 
  public:
   Simulator() = delete;

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -158,6 +158,8 @@ class Simulator {
   void InitalLocationCallbackRobot7(
     const geometry_msgs::PoseWithCovarianceStamped &msg);
 
+  // closed loop timer
+  double sim_time_;
  public:
   Simulator() = delete;
   explicit Simulator(const std::string& sim_config);

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -18,6 +18,8 @@
 \author  Joydeep Biswas, (C) 2011
 */
 //========================================================================
+// comment out to use ut_multirobot_sim's message.
+#define AMRL_MSGS
 
 #include <stdio.h>
 #include <iostream>
@@ -37,8 +39,13 @@
 #include "tf/transform_datatypes.h"
 #include "visualization_msgs/Marker.h"
 
-#include "ut_multirobot_sim/AckermannCurvatureDriveMsg.h"
-#include "ut_multirobot_sim/Localization2DMsg.h"
+#ifdef AMRL_MSGS
+  #include "amrl_msgs/Localization2DMsg.h"
+#else
+  #include "ut_multirobot_sim/Localization2DMsg.h"
+  //#include "ut_multirobot_sim/AckermannCurvatureDriveMsg.h"
+#endif
+
 
 #include "shared/math/geometry.h"
 #include "shared/util/timer.h"
@@ -80,7 +87,11 @@ class Simulator {
 
   sensor_msgs::LaserScan scanDataMsg_;
   nav_msgs::Odometry odometryTwistMsg_;
-  ut_multirobot_sim::Localization2DMsg localizationMsg_;
+  #ifdef AMRL_MSGS
+    amrl_msgs::Localization2DMsg localizationMsg_;
+  #else
+    ut_multirobot_sim::Localization2DMsg localizationMsg_;
+  #endif
 
   vector_map::VectorMap map_;
 
@@ -115,7 +126,7 @@ class Simulator {
   void drawObjects();
   void InitalLocationCallback(
       const geometry_msgs::PoseWithCovarianceStamped &msg);
-  void DriveCallback(const ut_multirobot_sim::AckermannCurvatureDriveMsg &msg);
+  // void DriveCallback(const ut_multirobot_sim::AckermannCurvatureDriveMsg &msg);
   void publishOdometry(int cur_robot_number);
   void publishLaser(int cur_robot_number);
   void publishVisualizationMarkers(int cur_robot_number);

--- a/src/simulator/simulator_main.cpp
+++ b/src/simulator/simulator_main.cpp
@@ -44,8 +44,9 @@ int main(int argc, char **argv) {
   }
 
   // main loop
-  RateLoop rate(40.0);
+  RateLoop rate(20.0);
   while (ros::ok()){
+
     ros::spinOnce();
     simulator.Run();
     rate.Sleep();

--- a/src/simulator/simulator_main.cpp
+++ b/src/simulator/simulator_main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
   }
 
   // main loop
-  RateLoop rate(200.0); // WARINING: ALSO CHANGE CONFIG dt
+  RateLoop rate(50.0); // WARINING: ALSO CHANGE CONFIG dt
   while (ros::ok()){
 
     ros::spinOnce();

--- a/src/simulator/simulator_main.cpp
+++ b/src/simulator/simulator_main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
   }
 
   // main loop
-  RateLoop rate(20.0);
+  RateLoop rate(200.0); // WARINING: ALSO CHANGE CONFIG dt
   while (ros::ok()){
 
     ros::spinOnce();

--- a/src/simulator/simulator_main.cpp
+++ b/src/simulator/simulator_main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
   }
 
   // main loop
-  RateLoop rate(50.0); // WARINING: ALSO CHANGE CONFIG dt
+  RateLoop rate(100.0); // WARINING: ALSO CHANGE CONFIG dt
   while (ros::ok()){
 
     ros::spinOnce();

--- a/src/simulator/vector_map.cpp
+++ b/src/simulator/vector_map.cpp
@@ -370,7 +370,7 @@ void VectorMap::Cleanup() {
   const float kMinLineLength = 0.05;
   vector<Line2f> new_lines;
   for (size_t i = 0; i < lines.size(); ++i) {
-    const Line2f l1 = lines[i];
+    const Line2f& l1 = lines[i];
     if (l1.Length() < kMinLineLength) continue;
     // Check if l1 intersects with any line in new lines.
     Vector2f p;
@@ -378,8 +378,10 @@ void VectorMap::Cleanup() {
     for (const Line2f l2 : new_lines) {
       if (l2.Intersection(l1, &p)) {
         const Vector2f shrink = kShrinkDistance * l1.Dir();
-        lines.push_back(Line2f(l1.p0, p - shrink));
-        lines.push_back(Line2f(p + shrink, l1.p1));
+        const Line2f a = Line2f(l1.p0, p - shrink);
+        const Line2f b = Line2f(p + shrink, l1.p1);
+        lines.push_back(a);
+        lines.push_back(b);
         intersection = true;
         break;
       }

--- a/src/simulator/vector_map.cpp
+++ b/src/simulator/vector_map.cpp
@@ -370,7 +370,7 @@ void VectorMap::Cleanup() {
   const float kMinLineLength = 0.05;
   vector<Line2f> new_lines;
   for (size_t i = 0; i < lines.size(); ++i) {
-    const Line2f& l1 = lines[i];
+    const Line2f l1 = lines[i];
     if (l1.Length() < kMinLineLength) continue;
     // Check if l1 intersects with any line in new lines.
     Vector2f p;

--- a/visualization.rviz
+++ b/visualization.rviz
@@ -124,7 +124,7 @@ Visualization Manager:
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /initialpose
+      Topic: /car0/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetGoal

--- a/visualization.rviz
+++ b/visualization.rviz
@@ -124,7 +124,7 @@ Visualization Manager:
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car0/initialpose
+      Topic: /initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetGoal

--- a/visualization_multi.rviz
+++ b/visualization_multi.rviz
@@ -82,7 +82,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.05000000074505806
       Style: Flat Squares
-      Topic: robot0/Cobot/Laser
+      Topic: single_robot/Cobot/Laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -138,7 +138,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.05000000074505806
       Style: Flat Squares
-      Topic: robot1/Cobot/Laser
+      Topic: robot_1/Cobot/Laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -168,7 +168,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.05000000074505806
       Style: Flat Squares
-      Topic: robot2/Cobot/Laser
+      Topic: robot_2/Cobot/Laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true

--- a/visualization_multi.rviz
+++ b/visualization_multi.rviz
@@ -82,7 +82,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.05000000074505806
       Style: Flat Squares
-      Topic: single_robot/Cobot/Laser
+      Topic: robot_0/Cobot/Laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -189,7 +189,7 @@ Visualization Manager:
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /single_robot/initialpose
+      Topic: /robot_0/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetInitialPose

--- a/visualization_multi.rviz
+++ b/visualization_multi.rviz
@@ -82,7 +82,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.05000000074505806
       Style: Flat Squares
-      Topic: car0/Cobot/Laser
+      Topic: robot0/Cobot/Laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -92,9 +92,9 @@ Visualization Manager:
       Marker Topic: /simulator_visualization
       Name: Map
       Namespaces:
-        car0_robot_position: true
-        car1_robot_position: true
-        car2_robot_position: true
+        robot0_robot_position: true
+        robot0_robot_position: true
+        robot0_robot_position: true
         map_lines: true
         object_lines: true
       Queue Size: 100
@@ -138,7 +138,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.05000000074505806
       Style: Flat Squares
-      Topic: car1/Cobot/Laser
+      Topic: robot1/Cobot/Laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -168,7 +168,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.05000000074505806
       Style: Flat Squares
-      Topic: car2/Cobot/Laser
+      Topic: robot2/Cobot/Laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -189,42 +189,42 @@ Visualization Manager:
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car0/initialpose
+      Topic: /single_robot/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car1/initialpose
+      Topic: /robot_1/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car2/initialpose
+      Topic: /robot_2/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5 
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /robot_3/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car3/initialpose
+      Topic: /robot_4/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car4/initialpose
+      Topic: /robot_5/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car5/initialpose
+      Topic: /robot_6/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetInitialPose
       Theta std deviation: 0.2617993950843811
-      Topic: /car6/initialpose
-      X std deviation: 0.5
-      Y std deviation: 0.5
-    - Class: rviz/SetInitialPose
-      Theta std deviation: 0.2617993950843811
-      Topic: /car7/initialpose
+      Topic: /robot_7/initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetGoal

--- a/visualization_multi.rviz
+++ b/visualization_multi.rviz
@@ -1,0 +1,279 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Grid1/Offset1
+        - /LaserScan1
+        - /LaserScan2
+        - /LaserScan3
+      Splitter Ratio: 0.5
+    Tree Height: 733
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: LaserScan
+  - Class: rviz/Help
+    Name: Help
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 2
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 30
+        Y: 30
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 40
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 255; 165; 39
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.05000000074505806
+      Style: Flat Squares
+      Topic: car0/Cobot/Laser
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /simulator_visualization
+      Name: Map
+      Namespaces:
+        car0_robot_position: true
+        car1_robot_position: true
+        car2_robot_position: true
+        map_lines: true
+        object_lines: true
+      Queue Size: 100
+      Value: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Scale: 3
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 52; 101; 164
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.05000000074505806
+      Style: Flat Squares
+      Topic: car1/Cobot/Laser
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 92; 53; 102
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.05000000074505806
+      Style: Flat Squares
+      Topic: car2/Cobot/Laser
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 255; 255; 255
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car0/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car1/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car2/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car3/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car4/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car5/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car6/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /car7/initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+    - Class: rviz_mouse_pub/MousePub
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 43.37636947631836
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 16.033729553222656
+        Y: 6.667145252227783
+        Z: -0.14977960288524628
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 1.5697963237762451
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 4.711787700653076
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1025
+  Help:
+    collapsed: false
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001d500000368fc020000000afb000000100044006900730070006c006100790073010000003d00000368000000c900fffffffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001e5000001ae00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb0000000a0049006d00610067006502000001bf000001e80000020800000213fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000800480065006c007000000001bf000000a20000006e00ffffff00000001000000d300000394fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003200000394000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d00000039fc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000005620000036800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1853
+  X: 1987
+  Y: 27


### PR DESCRIPTION
Major Changes:
1. Functionality changes:
    - In config/sim_config.lua, we can specify robot_number to indicate how many robots the simulator will simulate.
    - We can then specify the namespace (topic_prefix_list), type of robot (type_list), configuration file (config_list), initial x, y pose (config_list), initial angle (angle list), and color of car (RGB_list)
    - When Initializing the simulator will only initialize the first robot_number robots using the information from each list

2. visualization (rviz)
    - A hardcoded visualization file (visualization_multi.rviz) has been added to support setting the position of up to 8 cars.
    - laser topics are basically topic_prefix + "/" + laser topic, For example, if the laser topic is "/Cobot/Laser" and the topic_prefix is "car0" then the laser topic for car0 will be "car0/Cobot/Laser"
    - The Laser topics of the rviz file will have to be hardcoded to match the above convention published by the simulator

3. Major Code Refactoring
    - For most of the publishers there now exists a vector of publishers corresponding to each robot. The same methodology applies to TransformBroadcaster.
    - Two for loop has been added in the Run method. The first will update the position of each car and the second will update the visualization, laser topic, Odom msg, etc. 

Minor Bug Fix
    - Added DegToRad back to Ackermann config file
    - Updated the name of the map file to correspond to change in submodules. 
