### PR TITLE
Models are named by types, not robot names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ ROSBUILD_ADD_EXECUTABLE(${target}
   src/simulator/entity_base.cpp
   src/simulator/robot_model.cpp
   src/simulator/ackermann_model.cpp
-  src/simulator/cobot_model.cpp
+  src/simulator/omnidirectional_model.cpp
   src/simulator/diff_drive_model.cpp
   src/simulator/short_term_object.cpp
   src/simulator/human_object.cpp

--- a/config/ackermann_config.lua
+++ b/config/ackermann_config.lua
@@ -1,3 +1,7 @@
+function DegToRad(d)
+  return math.pi * d / 180
+end
+
 -- Kinematic and dynamic constraints for the car.
 ak_min_turn_radius = 0.98
 ak_max_speed = 1.2

--- a/config/default_init_config.lua
+++ b/config/default_init_config.lua
@@ -1,4 +1,5 @@
-map_name =  "maps/GDC3/GDC3.txt"
+-- map_name =  "maps/Joydeepb-Home/Joydeepb-Home.vectormap.txt"
+map_name =  "maps/Joydeepb-Driveway/Joydeepb-Driveway.vectormap.txt"
 -- Simulator starting location.
 start_x = 33.016267
 start_y = 21.534157

--- a/config/default_init_config.lua
+++ b/config/default_init_config.lua
@@ -1,4 +1,4 @@
-map_name =  "maps/GDC3/GDC3.txt"
+map_name =  "maps/GDC3/GDC3.vectormap.txt"
 -- Simulator starting location.
 start_x = 33.016267
 start_y = 21.534157

--- a/config/default_init_config.lua
+++ b/config/default_init_config.lua
@@ -1,5 +1,4 @@
--- map_name =  "maps/Joydeepb-Home/Joydeepb-Home.vectormap.txt"
-map_name =  "maps/Joydeepb-Driveway/Joydeepb-Driveway.vectormap.txt"
+map_name =  "maps/GDC3/GDC3.txt"
 -- Simulator starting location.
 start_x = 33.016267
 start_y = 21.534157

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -45,17 +45,19 @@ angular_error_rate = 0.1;
 
 -- Defining robot type enumerator
 local RobotType = {
-    F1TEN="F1TEN",
-    COBOT="COBOT",
-    BWIBOT="BWIBOT"
+    ACKERMANN_DRIVE="ACKERMANN_DRIVE",
+    OMNIDIRECTIONAL_DRIVE="OMNIDIRECTIONAL_DRIVE",
+    DIFF_DRIVE="DIFF_DRIVE"
 }
 
--- robot_type = RobotType.F1TEN
--- robot_config = "config/ackermann_config.lua"
--- robot_type = RobotType.BWIBOT
+robot_type = RobotType.ACKERMANN_DRIVE
+robot_config = "config/ackermann_config.lua"
+-- robot_type = RobotType.DIFF_DRIVE
 -- robot_config = "config/bwibot_config.lua"
-robot_type = RobotType.COBOT
-robot_config = "config/cobot_config.lua"
+-- robot_type = RobotType.OMNIDIRECTIONAL_DRIVE
+-- robot_config = "config/cobot_config.lua"
+robot_type = RobotType.DIFF_DRIVE
+robot_config = "config/ut_jackal_config.lua"
 
 laser_topic = "/Cobot/Laser"
 laser_frame = "base_laser"

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -51,13 +51,13 @@ local RobotType = {
 }
 
 robot_type = RobotType.ACKERMANN_DRIVE
-robot_config = "config/ackermann_config.lua"
+robot_config = "config/ut_automata_config.lua"
 -- robot_type = RobotType.DIFF_DRIVE
 -- robot_config = "config/bwibot_config.lua"
 -- robot_type = RobotType.OMNIDIRECTIONAL_DRIVE
 -- robot_config = "config/cobot_config.lua"
-robot_type = RobotType.DIFF_DRIVE
-robot_config = "config/ut_jackal_config.lua"
+-- robot_type = RobotType.DIFF_DRIVE
+-- robot_config = "config/ut_jackal_config.lua"
 
 laser_topic = "/Cobot/Laser"
 laser_frame = "base_laser"

--- a/config/ut_automata_config.lua
+++ b/config/ut_automata_config.lua
@@ -1,6 +1,4 @@
-function DegToRad(d)
-  return math.pi * d / 180
-end
+require("config.sim_config");
 
 -- Kinematic and dynamic constraints for the car.
 ak_min_turn_radius = 0.98

--- a/config/ut_jackal_config.lua
+++ b/config/ut_jackal_config.lua
@@ -1,0 +1,33 @@
+require("config.sim_config");
+
+-- MODEL PARAMETERS
+invert_linear_vel_cmds = false
+invert_angular_vel_cmds = false
+linear_pos_accel_limit = 3.0
+linear_neg_accel_limit = 3.0
+angular_pos_accel_limit = 3.0
+angular_neg_accel_limit = 3.0
+max_angular = 3.0
+max_linear_vel = 2.0
+drive_callback_topic = "/navigation/cmd_vel"
+diff_drive_odom_topic = "/odometry/filtered"
+linear_odom_scale = 1.0
+angular_odom_scale = 1.0
+
+
+-- SIMULATOR PARAMETERS
+
+-- tf
+publish_map_to_odom = false
+publish_foot_to_base = false
+
+-- Kinematic
+rear_axle_offset = 0.0
+min_turn_radius = 0.0
+
+laser_topic = "velodyne_2dscan"
+laser_loc = Vector3(0.15, 0, 0.155)
+car_width = 0.43
+car_length = 0.50
+car_height = 0.65;
+

--- a/src/simulator/omnidirectional_model.cpp
+++ b/src/simulator/omnidirectional_model.cpp
@@ -1,4 +1,4 @@
-#include "simulator/cobot_model.h"
+#include "simulator/omnidirectional_model.h"
 #include <eigen3/Eigen/src/Geometry/Rotation2D.h>
 #include "shared/util/timer.h"
 #include "shared/math/math_util.h"
@@ -16,7 +16,7 @@ using std::isfinite;
 using std::string;
 using std::vector;
 
-namespace cobot {
+namespace omnidrive {
 
 CONFIG_FLOAT(max_accel, "co_max_accel");
 CONFIG_FLOAT(max_angle_accel, "co_max_angle_accel");
@@ -30,7 +30,8 @@ CONFIG_FLOAT(base_r, "co_base_radius");
 CONFIG_STRING(drive_topic, "co_drive_callback_topic");
 CONFIG_STRING(odom_topic, "co_cobot_odom_topic");
 
-CobotModel::CobotModel(const vector<string>& config_files, ros::NodeHandle* n) :
+OmnidirectionalModel::OmnidirectionalModel(
+    const vector<string>& config_files, ros::NodeHandle* n) :
     RobotModel(),
     last_cmd_(),
     t_last_cmd_(0),
@@ -40,12 +41,12 @@ CobotModel::CobotModel(const vector<string>& config_files, ros::NodeHandle* n) :
   drive_subscriber_ = n->subscribe(
       CONFIG_drive_topic,
       1,
-      &CobotModel::DriveCallback,
+      &OmnidirectionalModel::DriveCallback,
       this);
   odom_publisher_ = n->advertise<CobotOdometryMsg>(CONFIG_odom_topic, 1);
 }
 
-void CobotModel::DriveCallback(const CobotDriveMsg& msg) {
+void OmnidirectionalModel::DriveCallback(const CobotDriveMsg& msg) {
   if (!isfinite(msg.velocity_x) ||
       !isfinite(msg.velocity_y) ||
       !isfinite(msg.velocity_r)) {
@@ -56,7 +57,7 @@ void CobotModel::DriveCallback(const CobotDriveMsg& msg) {
   t_last_cmd_ = GetMonotonicTime();
 }
 
-void CobotModel::PublishOdom(const float dt) {
+void OmnidirectionalModel::PublishOdom(const float dt) {
   const Vector2f w0 = Heading(CONFIG_w0);
   const Vector2f w1 = Heading(CONFIG_w1);
   const Vector2f w2 = Heading(CONFIG_w2);
@@ -78,7 +79,7 @@ void CobotModel::PublishOdom(const float dt) {
 }
 
 //TODO(jaholtz) Add noise
-void CobotModel::Step(const double &dt) {
+void OmnidirectionalModel::Step(const double &dt) {
   // TODO(jaholtz) For faster than real time simulation we may need
   // a wallclock invariant method for this.
   static const double kMaxCommandAge = 0.1;
@@ -121,4 +122,4 @@ void CobotModel::Step(const double &dt) {
   PublishOdom(dt);
 }
 
-} // namespace cobot
+} // namespace omnidrive

--- a/src/simulator/omnidirectional_model.h
+++ b/src/simulator/omnidirectional_model.h
@@ -6,12 +6,12 @@
 #include "ros/ros.h"
 #include "simulator/robot_model.h"
 
-#ifndef SRC_SIMULATOR_COBOT_MODEL_H_
-#define SRC_SIMULATOR_COBOT_MODEL_H_
+#ifndef SRC_SIMULATOR_OMNIDIRECTIONAL_MODEL_H_
+#define SRC_SIMULATOR_OMNIDIRECTIONAL_MODEL_H_
 
-namespace cobot {
+namespace omnidrive {
 
-class CobotModel : public robot_model::RobotModel {
+class OmnidirectionalModel : public robot_model::RobotModel {
  private:
   ut_multirobot_sim::CobotDriveMsg last_cmd_;
   double t_last_cmd_;
@@ -25,15 +25,16 @@ class CobotModel : public robot_model::RobotModel {
   void DriveCallback(const ut_multirobot_sim::CobotDriveMsg& msg);
 
  public:
-  CobotModel() = delete;
+  OmnidirectionalModel() = delete;
   // Intialize a default object reading from a file
-  CobotModel(const std::vector<std::string>& config_files, ros::NodeHandle* n);
-  ~CobotModel() = default;
+  OmnidirectionalModel(
+      const std::vector<std::string>& config_files, ros::NodeHandle* n);
+  ~OmnidirectionalModel() = default;
   // define Step function for updating
   void Step(const double& dt);
   void PublishOdom(const float dt);
 };
 
-}  // namespace cobot
+}  // namespace omnidrive
 
-#endif  // SRC_SIMULATOR_COBOT_MODEL_H_
+#endif  // SRC_SIMULATOR_OMNIDIRECTIONAL_MODEL_H_


### PR DESCRIPTION
Refactoring so that robot models are named by their types, not the names of robots.