### PR TITLE
Added multirobot support

### DIFF
--- a/config/default_init_config.lua
+++ b/config/default_init_config.lua
@@ -1,6 +1,4 @@
 map_name =  "maps/GDC3/GDC3.vectormap.txt"
 -- Simulator starting location.
-start_x = 33.016267
-start_y = 21.534157
-start_angle = 0.0
+start_poses = { {33.016267, 21.534157, 0} }
 

--- a/config/sim_config.lua
+++ b/config/sim_config.lua
@@ -61,7 +61,7 @@ local RobotType = {
 -- robot_config = "config/bwibot_config.lua"
 -- robot_type = RobotType.OMNIDIRECTIONAL_DRIVE
 -- robot_config = "config/cobot_config.lua"
-robot_type = RobotType.DIFF_DRIVE
+robot_types = { RobotType.DIFF_DRIVE }
 robot_config = "config/ut_jackal_config.lua"
 
 laser_topic = "/Cobot/Laser"

--- a/src/simulator/diff_drive_model.cpp
+++ b/src/simulator/diff_drive_model.cpp
@@ -54,19 +54,21 @@ CONFIG_FLOAT(angular_odom_scale, "angular_odom_scale");
 CONFIG_STRING(drive_topic, "drive_callback_topic");
 CONFIG_STRING(odom_topic, "diff_drive_odom_topic");
 
-DiffDriveModel::DiffDriveModel(const vector<string>& config_files, ros::NodeHandle* n) :
+DiffDriveModel::DiffDriveModel(const vector<string>& config_files, 
+                               ros::NodeHandle* n, 
+                               const std::string topic_prefix) :
     RobotModel(),
     last_cmd_(),
     t_last_cmd_(0),
     angular_error_(0, 1),
     config_reader_(config_files) {
-
     drive_subscriber_ = n->subscribe(
-      CONFIG_drive_topic,
+      topic_prefix + CONFIG_drive_topic,
       1,
       &DiffDriveModel::DriveCallback,
       this);
-    odom_publisher_ = n->advertise<nav_msgs::Odometry>(CONFIG_odom_topic, 1);
+    odom_publisher_ = 
+        n->advertise<nav_msgs::Odometry>(topic_prefix + CONFIG_odom_topic, 1);
     linear_vel_ = 0.0;
     angular_vel_ = 0.0;
     target_linear_vel_ = 0.0;

--- a/src/simulator/diff_drive_model.h
+++ b/src/simulator/diff_drive_model.h
@@ -38,7 +38,9 @@ class DiffDriveModel : public robot_model::RobotModel {
  public:
   DiffDriveModel() = delete;
   // Intialize a default object reading from a file
-  DiffDriveModel(const std::vector<std::string>& config_files, ros::NodeHandle* n);
+  DiffDriveModel(const std::vector<std::string>& config_files, 
+                 ros::NodeHandle* n, 
+                 const std::string topic_prefix);
   ~DiffDriveModel() = default;
   // define Step function for updating
   void Step(const double& dt);

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -60,23 +60,30 @@ class Simulator {
   config_reader::ConfigReader reader_;
   config_reader::ConfigReader init_config_reader_;
 
-  Pose2Df vel_;
-  Pose2Df cur_loc_;
-
   std::vector<std::unique_ptr<EntityBase>> objects;
 
-  ros::Subscriber initSubscriber;
+  struct RobotPubSub {
+    Pose2Df vel;
+    Pose2Df cur_loc;
 
-  ros::Publisher odometryTwistPublisher;
-  ros::Publisher laserPublisher;
-  ros::Publisher viz_laser_publisher_;
+    ros::Subscriber initSubscriber;
+    ros::Publisher odometryTwistPublisher;
+    ros::Publisher laserPublisher;
+    ros::Publisher vizLaserPublisher;
+    ros::Publisher posMarkerPublisher;
+    ros::Publisher truePosePublisher;
+    ros::Publisher localizationPublisher;
+    std::unique_ptr<robot_model::RobotModel> motion_model;
+
+    visualization_msgs::Marker robotPosMarker;
+  };
+
   ros::Publisher mapLinesPublisher;
-  ros::Publisher posMarkerPublisher;
   ros::Publisher objectLinesPublisher;
-  ros::Publisher truePosePublisher;
-  ros::Publisher localizationPublisher;
-  tf::TransformBroadcaster *br;
 
+  std::vector<RobotPubSub> robot_pub_subs_;
+
+  tf::TransformBroadcaster *br;
   sensor_msgs::LaserScan scanDataMsg;
   nav_msgs::Odometry odometryTwistMsg;
   ut_multirobot_sim::Localization2DMsg localizationMsg;
@@ -84,7 +91,6 @@ class Simulator {
   vector_map::VectorMap map_;
 
   visualization_msgs::Marker lineListMarker;
-  visualization_msgs::Marker robotPosMarker;
   visualization_msgs::Marker objectLinesMarker;
 
   static const float DT;
@@ -92,9 +98,6 @@ class Simulator {
 
   std::default_random_engine rng_;
   std::normal_distribution<float> laser_noise_;
-
-  std::unique_ptr<robot_model::RobotModel> motion_model_;
-  std::string robot_type_;
 
  private:
   void initVizMarker(visualization_msgs::Marker &vizMarker, string ns, int id,
@@ -111,6 +114,7 @@ class Simulator {
   void publishLaser();
   void publishVisualizationMarkers();
   void publishTransform();
+  void publishLocalization();
   void update();
   void loadObject();
 


### PR DESCRIPTION
Supports adding robots by adding entries to the two lists in the config file for motion model type and start pose. The code is written to encapsulate the relevant state for each agent inside of `RobotPubSub`. It properly handles prefixation for each topic with the `/robotX/` string without any hard coding of prefixes or any limit on the number of agents.

[Here is a video of multiple full control stacks being deployed with the simulator.](https://www.youtube.com/watch?v=NE6JRAat-rE)