### PR TITLE
Fixed bug in robot line handling never appearing. Added shape to diff drive robot.

### DIFF
--- a/src/simulator/diff_drive_model.h
+++ b/src/simulator/diff_drive_model.h
@@ -35,6 +35,8 @@ class DiffDriveModel : public robot_model::RobotModel {
     // Receives drive callback messages and stores them
     void DriveCallback(const geometry_msgs::Twist& msg);
 
+    void UpdatePoseLines();
+
  public:
   DiffDriveModel() = delete;
   // Intialize a default object reading from a file


### PR DESCRIPTION
Robots now can properly support outer shape via `GetLine()` like with humans. Outer shape is removed on the robot doing the observation.